### PR TITLE
Remove all notification extension artifacts from Xcode project

### DIFF
--- a/.github/workflows/ios-build-deploy.yml
+++ b/.github/workflows/ios-build-deploy.yml
@@ -135,7 +135,7 @@ jobs:
             -destination "generic/platform=iOS" \
             MARKETING_VERSION="${{ env.APP_VERSION }}" \
             CURRENT_PROJECT_VERSION="${{ env.BUILD_NUMBER }}" \
-            | xcbeautify || true
+            | xcbeautify
 
       - name: Create ExportOptions.plist
         run: |

--- a/ios/Wellvo.xcodeproj/project.pbxproj
+++ b/ios/Wellvo.xcodeproj/project.pbxproj
@@ -68,9 +68,6 @@
 		/* New Services */
 		B1C00009 /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C00009; };
 		B1C0000A /* HeartbeatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C0000A; };
-		/* Notification Service Extension */
-		B2A00001 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A00001; };
-		F2P00002 /* WellvoNotificationService.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = F2P00001; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -127,12 +124,8 @@
 		F1G00001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		/* Config */
 		F1X00001 /* BuildConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = BuildConfig.xcconfig; sourceTree = "<group>"; };
-		/* Notification Service Extension */
-		F2A00001 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
-		F2A00002 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		/* Product */
 		F1P00001 /* Wellvo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Wellvo.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		F2P00001 /* WellvoNotificationService.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WellvoNotificationService.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -146,13 +139,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D2000001 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -160,18 +146,8 @@
 			isa = PBXGroup;
 			children = (
 				G1000002 /* Wellvo */,
-				G2A00001 /* WellvoNotificationService */,
 				G1000003 /* Products */,
 			);
-			sourceTree = "<group>";
-		};
-		G2A00001 /* WellvoNotificationService */ = {
-			isa = PBXGroup;
-			children = (
-				F2A00001 /* NotificationService.swift */,
-				F2A00002 /* Info.plist */,
-			);
-			path = WellvoNotificationService;
 			sourceTree = "<group>";
 		};
 		G1000002 /* Wellvo */ = {
@@ -193,7 +169,6 @@
 			isa = PBXGroup;
 			children = (
 				F1P00001 /* Wellvo.app */,
-				F2P00001 /* WellvoNotificationService.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -356,42 +331,7 @@
 			productReference = F1P00001 /* Wellvo.app */;
 			productType = "com.apple.product-type.application";
 		};
-		T2000001 /* WellvoNotificationService */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = CL000003 /* Build configuration list for PBXNativeTarget "WellvoNotificationService" */;
-			buildPhases = (
-				S2000001 /* Sources */,
-				D2000001 /* Frameworks */,
-				R2000001 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = WellvoNotificationService;
-			productName = WellvoNotificationService;
-			productReference = F2P00001 /* WellvoNotificationService.appex */;
-			productType = "com.apple.product-type.app-extension";
-		};
 /* End PBXNativeTarget section */
-
-/* Begin PBXContainerItemProxy section */
-		CIP00001 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = PR000001 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = T2000001;
-			remoteInfo = WellvoNotificationService;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXTargetDependency section */
-		TD000001 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = T2000001 /* WellvoNotificationService */;
-			targetProxy = CIP00001 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXProject section */
 		PR000001 /* Project object */ = {
@@ -428,20 +368,6 @@
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXCopyFilesBuildPhase section */
-		E1000001 /* Embed App Extensions */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 13;
-			files = (
-				F2P00002 /* WellvoNotificationService.appex in Embed App Extensions */,
-			);
-			name = "Embed App Extensions";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		S1000001 /* Sources */ = {
@@ -494,14 +420,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		S2000001 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				B2A00001 /* NotificationService.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -510,13 +428,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				B1G00001 /* Assets.xcassets in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		R2000001 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -636,54 +547,6 @@
 			};
 			name = Release;
 		};
-		BC000005 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = WellvoNotificationService/WellvoNotificationService.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = WellvoNotificationService/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = WellvoNotificationService;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
-				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.wellvo.ios.notification-service";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		BC000006 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CODE_SIGN_ENTITLEMENTS = WellvoNotificationService/WellvoNotificationService.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = WellvoNotificationService/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = WellvoNotificationService;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@executable_path/../../Frameworks",
-				);
-				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.wellvo.ios.notification-service";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -701,15 +564,6 @@
 			buildConfigurations = (
 				BC000003 /* Debug */,
 				BC000004 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		CL000003 /* Build configuration list for PBXNativeTarget "WellvoNotificationService" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				BC000005 /* Debug */,
-				BC000006 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
The extension target was added but never provisioned for code signing, causing the archive to silently fail. This removes every orphaned reference (target, build phases, build configs, groups, file refs) so the project is back to a single-target build.

Also removes || true from the archive step so failures are no longer swallowed.

https://claude.ai/code/session_016YALdNyPfmA2TLjFr88Yos