### PR TITLE
Remove App Groups entitlement that provisioning profile lacks

### DIFF
--- a/ios/Wellvo/Wellvo.entitlements
+++ b/ios/Wellvo/Wellvo.entitlements
@@ -10,9 +10,5 @@
 	</array>
 	<key>com.apple.developer.usernotifications.time-sensitive</key>
 	<true/>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.com.wellvo.ios</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
The App Groups capability (group.com.wellvo.ios) was added for sharing data between the main app and notification extension, but the current provisioning profile doesn't include this capability. Since the extension target has been removed, App Groups is not needed.

https://claude.ai/code/session_016YALdNyPfmA2TLjFr88Yos