### PR TITLE
Fix functions.invoke() return type for Supabase Swift SDK v2

### DIFF
--- a/ios/Wellvo/Services/CheckInService.swift
+++ b/ios/Wellvo/Services/CheckInService.swift
@@ -39,13 +39,10 @@ actor CheckInService {
         }
 
         // Use the edge function which handles location, response type, and alerts
-        let response = try await supabase.functions.invoke(
+        let result: CheckInResponse = try await supabase.functions.invoke(
             "process-checkin-response",
             options: .init(body: body)
         )
-
-        // Decode the check-in from the response
-        let result = try JSONDecoder().decode(CheckInResponse.self, from: response.data)
         return result.checkin
     }
 


### PR DESCRIPTION
Supabase Swift SDK v2 functions.invoke() returns Void by default. Use the generic overload to decode the response directly instead of accessing .data on the result.

https://claude.ai/code/session_016YALdNyPfmA2TLjFr88Yos