### PR TITLE
Improve iOS build pipeline reliability with archive verification

### DIFF
--- a/.github/workflows/ios-build-deploy.yml
+++ b/.github/workflows/ios-build-deploy.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Build and archive
         working-directory: ios
         run: |
+          set -o pipefail
           xcodebuild archive \
             -project Wellvo.xcodeproj \
             -scheme Wellvo \
@@ -136,6 +137,12 @@ jobs:
             MARKETING_VERSION="${{ env.APP_VERSION }}" \
             CURRENT_PROJECT_VERSION="${{ env.BUILD_NUMBER }}" \
             | xcbeautify
+
+          # Verify archive was created
+          if [ ! -d "$RUNNER_TEMP/Wellvo.xcarchive" ]; then
+            echo "::error::Archive was not created at $RUNNER_TEMP/Wellvo.xcarchive"
+            exit 1
+          fi
 
       - name: Create ExportOptions.plist
         run: |


### PR DESCRIPTION
## Summary
Enhanced the iOS build and archive step in the CI/CD pipeline to improve error detection and reliability by adding pipeline failure handling and archive creation verification.

## Key Changes
- Added `set -o pipefail` to ensure the build step fails if any command in the pipeline fails (e.g., if `xcbeautify` encounters an error)
- Added explicit verification that the `.xcarchive` file was successfully created after the build completes
- Provides clear error messaging if archive creation fails, preventing silent failures that could lead to downstream issues

## Implementation Details
The archive verification check ensures that if the `xcodebuild archive` command completes without error but fails to produce the expected archive file, the workflow will immediately fail with a descriptive error message rather than proceeding to subsequent steps that depend on the archive existing.

https://claude.ai/code/session_01GaUdo3mrvz9trNh1K6Pr2J