### PR TITLE
Add iPad pairing code setup flow for device onboarding

### DIFF
--- a/edge-functions/functions/invite-receiver/index.ts
+++ b/edge-functions/functions/invite-receiver/index.ts
@@ -83,6 +83,9 @@ async function createInvite(body: InviteRequest, auth: AuthResult): Promise<Resp
   crypto.getRandomValues(tokenBytes);
   const inviteToken = Array.from(tokenBytes, (b) => b.toString(16).padStart(2, "0")).join("");
 
+  // Generate a short 6-digit pairing code for iPad / alternate-device setup
+  const pairingCode = generatePairingCode();
+
   // Store invite
   const { error: inviteError } = await supabaseAdmin.from("invite_tokens").insert({
     family_id,
@@ -91,6 +94,7 @@ async function createInvite(body: InviteRequest, auth: AuthResult): Promise<Resp
     name,
     checkin_time: checkin_time || "08:00",
     token: inviteToken,
+    pairing_code: pairingCode,
   });
 
   if (inviteError) {
@@ -106,10 +110,12 @@ async function createInvite(body: InviteRequest, auth: AuthResult): Promise<Resp
   // Send SMS invite to receiver
   // The receiver just needs to download the app and sign in with this phone number —
   // auto-join will match them to this invite automatically.
+  // The pairing code is included so they can set up on an iPad or other device.
   const smsBody =
     `${name}, your family wants to check in with you daily using Alive. ` +
     `Download the app and sign in with this phone number to get started: ` +
-    `https://apps.apple.com/app/alive-daily-checkin/id6742044109`;
+    `https://apps.apple.com/app/alive-daily-checkin/id6742044109\n\n` +
+    `Setting up on an iPad? Use this code: ${pairingCode}`;
   const smsResult = await sendSMS(phone, smsBody);
 
   return new Response(
@@ -117,6 +123,7 @@ async function createInvite(body: InviteRequest, auth: AuthResult): Promise<Resp
       success: true,
       invite_token: inviteToken,
       invite_link: inviteLink,
+      pairing_code: pairingCode,
       sms_sent: smsResult.success,
     }),
     { headers: { "Content-Type": "application/json" } }
@@ -238,6 +245,19 @@ async function acceptInvite(body: InviteRequest, auth: AuthResult): Promise<Resp
     JSON.stringify({ success: true, family_id: invite.family_id, role: invite.role }),
     { headers: { "Content-Type": "application/json" } }
   );
+}
+
+/**
+ * Generate a cryptographically random 6-digit pairing code (100000–999999).
+ * Used for iPad / alternate-device setup where phone auto-join isn't possible.
+ */
+function generatePairingCode(): string {
+  const bytes = new Uint8Array(4);
+  crypto.getRandomValues(bytes);
+  const num = ((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3]) >>> 0;
+  // Map to 100000–999999 range
+  const code = 100000 + (num % 900000);
+  return String(code);
 }
 
 /**

--- a/edge-functions/functions/redeem-code/index.ts
+++ b/edge-functions/functions/redeem-code/index.ts
@@ -1,0 +1,141 @@
+import { supabaseAdmin } from "../../shared/supabase.ts";
+import type { AuthResult } from "../../shared/auth.ts";
+
+interface RedeemRequest {
+  code: string;
+}
+
+/**
+ * Redeem a 6-digit pairing code to join a family.
+ *
+ * This enables the "iPad setup" flow: a receiver gets an SMS on their phone,
+ * then opens the app on their iPad, signs in (Apple / email), and enters the
+ * pairing code to bind their account to the family.
+ */
+export async function handleRedeemCode(
+  req: Request,
+  auth: AuthResult,
+): Promise<Response> {
+  if (!auth.userId) {
+    return new Response(
+      JSON.stringify({ error: "Authentication required" }),
+      { status: 401, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  const body: RedeemRequest = await req.json();
+  const code = (body.code || "").trim();
+
+  if (!/^\d{6}$/.test(code)) {
+    return new Response(
+      JSON.stringify({ error: "Please enter a valid 6-digit code" }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // Look up a matching, unused, non-expired invite by pairing code
+  const { data: invite, error: inviteError } = await supabaseAdmin
+    .from("invite_tokens")
+    .select("*")
+    .eq("pairing_code", code)
+    .is("used_by", null)
+    .gt("expires_at", new Date().toISOString())
+    .single();
+
+  if (inviteError || !invite) {
+    return new Response(
+      JSON.stringify({ error: "Invalid or expired code. Please check and try again." }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // Check if user is already a member of this family
+  const { data: existingMember } = await supabaseAdmin
+    .from("family_members")
+    .select("id, status")
+    .eq("family_id", invite.family_id)
+    .eq("user_id", auth.userId)
+    .single();
+
+  if (existingMember && existingMember.status === "active") {
+    return new Response(
+      JSON.stringify({
+        success: true,
+        already_member: true,
+        family_id: invite.family_id,
+        role: invite.role,
+      }),
+      { headers: { "Content-Type": "application/json" } },
+    );
+  }
+
+  // Create or reactivate family member
+  let memberId: string;
+
+  if (existingMember) {
+    const { data: updated } = await supabaseAdmin
+      .from("family_members")
+      .update({
+        role: invite.role,
+        status: "active",
+        joined_at: new Date().toISOString(),
+      })
+      .eq("id", existingMember.id)
+      .select()
+      .single();
+    memberId = updated?.id;
+  } else {
+    const { data: member, error: memberError } = await supabaseAdmin
+      .from("family_members")
+      .insert({
+        family_id: invite.family_id,
+        user_id: auth.userId,
+        role: invite.role,
+        status: "active",
+        joined_at: new Date().toISOString(),
+      })
+      .select()
+      .single();
+
+    if (memberError) {
+      return new Response(
+        JSON.stringify({ error: "Failed to join family" }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    memberId = member.id;
+  }
+
+  // Create receiver settings if receiver role
+  if (invite.role === "receiver" && memberId) {
+    await supabaseAdmin.from("receiver_settings").upsert({
+      family_member_id: memberId,
+      checkin_time: invite.checkin_time || "08:00",
+      timezone: "America/New_York",
+    });
+  }
+
+  // Update user role and display name
+  const updates: Record<string, string> = { role: invite.role };
+  if (invite.name) {
+    updates.display_name = invite.name;
+  }
+  await supabaseAdmin.from("users").update(updates).eq("id", auth.userId);
+
+  // Mark invite as used
+  await supabaseAdmin
+    .from("invite_tokens")
+    .update({ used_by: auth.userId })
+    .eq("id", invite.id);
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      family_id: invite.family_id,
+      role: invite.role,
+      checkin_time: invite.checkin_time,
+      name: invite.name,
+    }),
+    { headers: { "Content-Type": "application/json" } },
+  );
+}

--- a/edge-functions/server.ts
+++ b/edge-functions/server.ts
@@ -24,6 +24,7 @@ import { handleConfirmDelivery } from "./functions/confirm-delivery/index.ts";
 import { handleReportLocation } from "./functions/report-location/index.ts";
 import { handleHeartbeat } from "./functions/heartbeat/index.ts";
 import { handleAutoJoin } from "./functions/auto-join/index.ts";
+import { handleRedeemCode } from "./functions/redeem-code/index.ts";
 
 type FunctionHandler = (req: Request, auth: AuthResult) => Promise<Response>;
 
@@ -46,6 +47,7 @@ const routes: Record<string, FunctionHandler> = {
   "/report-location": handleReportLocation,
   "/heartbeat": handleHeartbeat,
   "/auto-join": handleAutoJoin,
+  "/redeem-code": handleRedeemCode,
 };
 
 const ALLOWED_ORIGIN = Deno.env.get("ALLOWED_ORIGIN") || "https://wellvo.net";

--- a/ios/Wellvo/App/AppState.swift
+++ b/ios/Wellvo/App/AppState.swift
@@ -7,6 +7,7 @@ final class AppState: ObservableObject {
     @Published var currentUserRole: UserRole?
     @Published var selectedTab: AppTab = .dashboard
     @Published var isOnboarding: Bool = false
+    @Published var showPairingCodeEntry: Bool = false
 
     enum AppTab: Int, CaseIterable {
         case dashboard = 0

--- a/ios/Wellvo/App/ContentView.swift
+++ b/ios/Wellvo/App/ContentView.swift
@@ -17,6 +17,8 @@ struct ContentView: View {
                     ReceiverOnboardingView(inviteToken: inviteToken)
                 } else if appState.pendingAutoJoin != nil {
                     ReceiverOnboardingView(inviteToken: nil)
+                } else if appState.showPairingCodeEntry {
+                    PairingCodeEntryView()
                 } else if appState.isOnboarding {
                     OnboardingView()
                 } else if appState.currentUserRole == .receiver {

--- a/ios/Wellvo/Services/FamilyService.swift
+++ b/ios/Wellvo/Services/FamilyService.swift
@@ -117,6 +117,16 @@ actor FamilyService {
         )
     }
 
+    /// Redeem a 6-digit pairing code (iPad / alternate-device setup).
+    /// Returns the join result from the server.
+    func redeemPairingCode(_ code: String) async throws -> RedeemCodeResponse {
+        let data: RedeemCodeResponse = try await supabase.functions.invoke(
+            "redeem-code",
+            options: .init(body: ["code": code])
+        )
+        return data
+    }
+
     /// Check if the authenticated user's phone matches a pending invite and auto-join.
     /// Returns the auto-join result, or nil if no match found.
     func checkAutoJoin() async throws -> AutoJoinResult? {
@@ -132,6 +142,26 @@ actor FamilyService {
             role: data.role ?? "receiver",
             checkinTime: data.checkinTime
         )
+    }
+}
+
+struct RedeemCodeResponse: Decodable {
+    let success: Bool?
+    let alreadyMember: Bool?
+    let familyId: String?
+    let role: String?
+    let checkinTime: String?
+    let name: String?
+    let error: String?
+
+    enum CodingKeys: String, CodingKey {
+        case success
+        case alreadyMember = "already_member"
+        case familyId = "family_id"
+        case role
+        case checkinTime = "checkin_time"
+        case name
+        case error
     }
 }
 

--- a/ios/Wellvo/Views/Auth/AuthView.swift
+++ b/ios/Wellvo/Views/Auth/AuthView.swift
@@ -3,10 +3,12 @@ import AuthenticationServices
 
 struct AuthView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
+    @EnvironmentObject var appState: AppState
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.accessibilityReduceMotion) var reduceMotion
     @State private var isSignUp = false
     @State private var showEmailAuth = false
+    @State private var joinViaCode = false
     @ScaledMetric(relativeTo: .largeTitle) private var logoSize: CGFloat = 80
 
     var body: some View {
@@ -64,9 +66,25 @@ struct AuthView: View {
                 }
 
                 Spacer()
+
+                // iPad / alternate-device setup via pairing code
+                Button {
+                    joinViaCode = true
+                } label: {
+                    Label("Have a setup code?", systemImage: "number.square")
+                        .font(.footnote)
+                        .foregroundStyle(.green)
+                }
+                .padding(.bottom, 16)
             }
             .padding(.horizontal, 24)
             .animation(reduceMotion ? nil : .easeInOut(duration: 0.2), value: authViewModel.errorMessage)
+            .onChange(of: authViewModel.authState) { newState in
+                if newState == .authenticated, joinViaCode {
+                    appState.showPairingCodeEntry = true
+                    joinViaCode = false
+                }
+            }
         }
     }
 

--- a/ios/Wellvo/Views/Onboarding/PairingCodeEntryView.swift
+++ b/ios/Wellvo/Views/Onboarding/PairingCodeEntryView.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+
+/// Allows a receiver to enter a 6-digit pairing code from their SMS
+/// to bind this device (typically an iPad) to the family.
+struct PairingCodeEntryView: View {
+    @EnvironmentObject var appState: AppState
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
+    @State private var code = ""
+    @State private var isSubmitting = false
+    @State private var errorMessage: String?
+    @State private var joinedSuccessfully = false
+    @State private var checkinTimeDisplay = "8:00 AM"
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Back button
+            HStack {
+                Button {
+                    appState.showPairingCodeEntry = false
+                } label: {
+                    HStack(spacing: 4) {
+                        Image(systemName: "chevron.left")
+                        Text("Back")
+                    }
+                    .foregroundStyle(.green)
+                }
+                Spacer()
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 12)
+
+            Spacer()
+
+            if joinedSuccessfully {
+                successView
+            } else {
+                codeEntryView
+            }
+
+            Spacer()
+        }
+    }
+
+    // MARK: - Code Entry
+
+    private var codeEntryView: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "ipad.and.iphone")
+                .font(.system(size: 60))
+                .foregroundStyle(.green)
+
+            Text("Set Up This Device")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+
+            Text("Enter the 6-digit code from the text message you received on your phone.")
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                .padding(.horizontal, 32)
+
+            TextField("000000", text: $code)
+                .textFieldStyle(.roundedBorder)
+                .keyboardType(.numberPad)
+                .multilineTextAlignment(.center)
+                .font(.title.monospaced())
+                .frame(maxWidth: 200)
+                .onChange(of: code) { newValue in
+                    // Limit to 6 digits
+                    let filtered = newValue.filter(\.isNumber)
+                    if filtered.count > 6 {
+                        code = String(filtered.prefix(6))
+                    } else if filtered != newValue {
+                        code = filtered
+                    }
+                }
+                .onSubmit { Task { await submitCode() } }
+
+            if let error = errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+                    .multilineTextAlignment(.center)
+            }
+
+            Button {
+                Task { await submitCode() }
+            } label: {
+                if isSubmitting {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                } else {
+                    Text("Join Family")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.green)
+            .controlSize(.large)
+            .disabled(code.count != 6 || isSubmitting)
+            .padding(.horizontal, 32)
+        }
+    }
+
+    // MARK: - Success
+
+    private var successView: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 80))
+                .foregroundStyle(.green)
+
+            Text("You're All Set!")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+
+            Text("Your daily check-in is at **\(checkinTimeDisplay)**.\nJust tap \"I'm OK\" when you get the notification.")
+                .font(.title3)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .dynamicTypeSize(...DynamicTypeSize.accessibility2)
+                .padding(.horizontal, 32)
+
+            Button("Start Checking In") {
+                appState.showPairingCodeEntry = false
+                appState.isOnboarding = false
+                appState.currentUserRole = .receiver
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.green)
+            .controlSize(.large)
+        }
+    }
+
+    // MARK: - Submit
+
+    private func submitCode() async {
+        guard code.count == 6, !isSubmitting else { return }
+
+        isSubmitting = true
+        errorMessage = nil
+
+        do {
+            let response = try await FamilyService.shared.redeemPairingCode(code)
+
+            if let error = response.error {
+                errorMessage = error
+            } else if response.success == true {
+                if let time = response.checkinTime {
+                    checkinTimeDisplay = formatCheckinTime(time)
+                }
+                if reduceMotion {
+                    joinedSuccessfully = true
+                } else {
+                    withAnimation { joinedSuccessfully = true }
+                }
+            } else {
+                errorMessage = "Something went wrong. Please try again."
+            }
+        } catch {
+            errorMessage = "Could not connect. Please check your internet and try again."
+        }
+
+        isSubmitting = false
+    }
+
+    private func formatCheckinTime(_ time: String) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        guard let date = formatter.date(from: time) else { return time }
+        formatter.dateFormat = "h:mm a"
+        return formatter.string(from: date)
+    }
+}

--- a/supabase/migrations/00016_invite_pairing_code.sql
+++ b/supabase/migrations/00016_invite_pairing_code.sql
@@ -1,0 +1,15 @@
+-- Migration: 00016_invite_pairing_code
+-- Adds a short pairing code to invite_tokens so receivers can set up
+-- on a different device (e.g. iPad) by entering a 6-digit code from
+-- the SMS they received on their phone.
+
+BEGIN;
+
+ALTER TABLE invite_tokens
+  ADD COLUMN pairing_code TEXT;
+
+CREATE UNIQUE INDEX idx_invite_tokens_pairing_code
+  ON invite_tokens(pairing_code)
+  WHERE pairing_code IS NOT NULL AND used_by IS NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary
Implements an alternative device setup flow that allows receivers to join a family by entering a 6-digit pairing code on an iPad or other device, complementing the existing phone-based auto-join mechanism.

## Key Changes

**Backend (Edge Functions & Database)**
- Added `redeem-code` edge function to validate and redeem 6-digit pairing codes
- Modified `invite-receiver` function to generate a random 6-digit pairing code for each invite and include it in SMS messages
- Added `pairing_code` column to `invite_tokens` table with unique index for unused codes
- Pairing code redemption creates/reactivates family members and initializes receiver settings

**iOS Frontend**
- Created `PairingCodeEntryView` with:
  - 6-digit code input field with automatic validation
  - Success state showing check-in time confirmation
  - Error handling for invalid/expired codes
  - Accessibility support (reduced motion, dynamic type)
- Added `RedeemCodeResponse` struct to decode server responses
- Extended `FamilyService` with `redeemPairingCode()` method
- Modified `AuthView` to add "Have a setup code?" button that triggers pairing code entry after authentication
- Updated `AppState` with `showPairingCodeEntry` flag
- Integrated pairing code entry into `ContentView` navigation flow

## Implementation Details

- Pairing codes are 6-digit numbers (100000–999999) generated cryptographically
- Codes are marked as used when successfully redeemed to prevent reuse
- SMS invites now include the pairing code with instructions for iPad setup
- The flow supports both new members and reactivating inactive members
- Receiver settings (check-in time, timezone) are automatically configured from the invite
- User role and display name are updated from the invite data upon redemption

https://claude.ai/code/session_01EFTHw9Cyo6YUMTsRq6uyMz