### PR TITLE
Remove background location tracking and add nonce to Apple Sign-In

### DIFF
--- a/ios/Wellvo/Info.plist
+++ b/ios/Wellvo/Info.plist
@@ -29,13 +29,10 @@
 	</array>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Wellvo uses your location to include it with your check-in so your family knows you're safe.</string>
-	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>Wellvo uses your location in the background to alert your family if you leave your safe zone.</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
 		<string>remote-notification</string>
-		<string>location</string>
 	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>

--- a/ios/Wellvo/Services/LocationService.swift
+++ b/ios/Wellvo/Services/LocationService.swift
@@ -24,7 +24,6 @@ class LocationService: NSObject, CLLocationManagerDelegate {
         super.init()
         locationManager.delegate = self
         locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
-        locationManager.allowsBackgroundLocationUpdates = true
         locationManager.pausesLocationUpdatesAutomatically = true
     }
 

--- a/ios/Wellvo/ViewModels/AuthViewModel.swift
+++ b/ios/Wellvo/ViewModels/AuthViewModel.swift
@@ -89,7 +89,10 @@ final class AuthViewModel: ObservableObject {
     /// Prepare the Apple Sign-In request.
     /// Call this from the SignInWithAppleButton's `onRequest` closure.
     func configureAppleSignInRequest(_ request: ASAuthorizationAppleIDRequest) {
+        let rawNonce = Self.randomNonceString()
+        currentRawNonce = rawNonce
         request.requestedScopes = [.fullName, .email]
+        request.nonce = Self.sha256(rawNonce)
     }
 
     // MARK: - Nonce Helpers (synchronous, no actor hop needed)


### PR DESCRIPTION
## Summary
This PR removes background location tracking capabilities from the app and adds security improvements to the Apple Sign-In flow by implementing nonce validation.

## Key Changes
- **Removed background location tracking**: Disabled background location updates in `LocationService` by removing the `allowsBackgroundLocationUpdates = true` configuration
- **Removed location background mode**: Removed the `location` entry from `UIBackgroundModes` in Info.plist, keeping only `fetch` and `remote-notification`
- **Removed location privacy description**: Removed the `NSLocationAlwaysAndWhenInUseUsageDescription` key from Info.plist that described background location usage
- **Added nonce to Apple Sign-In**: Implemented nonce generation and validation in `AuthViewModel.configureAppleSignInRequest()` by:
  - Generating a random nonce string
  - Storing the raw nonce for later verification
  - Setting the SHA256-hashed nonce on the authorization request

## Implementation Details
The nonce implementation follows Apple's recommended security practices for Sign in with Apple, helping prevent replay attacks by ensuring the authentication response is tied to the specific request. The background location tracking removal simplifies the app's location permissions model to only support foreground location access for check-ins.

https://claude.ai/code/session_01YBzFAbEqtbSeqUHgjS1Pzo