### PR TITLE
Add PairingCodeEntryView.swift to Xcode project compile sources

### DIFF
--- a/ios/Wellvo.xcodeproj/project.pbxproj
+++ b/ios/Wellvo.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		/* Views/Onboarding */
 		B1F00002 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F00002; };
 		B1F00003 /* ReceiverOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F00003; };
+		B1F00011 /* PairingCodeEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F00011; };
 		/* Views/Owner */
 		B1F00004 /* CalendarHeatmapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F00004; };
 		B1F00005 /* CheckInReportGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F00005; };
@@ -109,6 +110,7 @@
 		F1F00001 /* AuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthView.swift; sourceTree = "<group>"; };
 		F1F00002 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		F1F00003 /* ReceiverOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiverOnboardingView.swift; sourceTree = "<group>"; };
+		F1F00011 /* PairingCodeEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PairingCodeEntryView.swift; sourceTree = "<group>"; };
 		F1F00004 /* CalendarHeatmapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarHeatmapView.swift; sourceTree = "<group>"; };
 		F1F00005 /* CheckInReportGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInReportGenerator.swift; sourceTree = "<group>"; };
 		F1F00006 /* CheckInTrendChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckInTrendChartView.swift; sourceTree = "<group>"; };
@@ -264,6 +266,7 @@
 			children = (
 				F1F00002 /* OnboardingView.swift */,
 				F1F00003 /* ReceiverOnboardingView.swift */,
+				F1F00011 /* PairingCodeEntryView.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -406,6 +409,7 @@
 				B1F00001 /* AuthView.swift in Sources */,
 				B1F00002 /* OnboardingView.swift in Sources */,
 				B1F00003 /* ReceiverOnboardingView.swift in Sources */,
+				B1F00011 /* PairingCodeEntryView.swift in Sources */,
 				B1F00004 /* CalendarHeatmapView.swift in Sources */,
 				B1F00005 /* CheckInReportGenerator.swift in Sources */,
 				B1F00006 /* CheckInTrendChartView.swift in Sources */,


### PR DESCRIPTION
The file existed on disk but was never registered in project.pbxproj, causing the CI archive to fail with "cannot find PairingCodeEntryView in scope". Added PBXFileReference (F1F00011), PBXBuildFile (B1F00011), group entry, and Sources build phase entry.

https://claude.ai/code/session_01YBzFAbEqtbSeqUHgjS1Pzo