### PR TITLE
Add NSLocationAlwaysAndWhenInUseUsageDescription to Info.plist

### DIFF
--- a/ios/Wellvo/Info.plist
+++ b/ios/Wellvo/Info.plist
@@ -27,6 +27,8 @@
 			</array>
 		</dict>
 	</array>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Wellvo uses your location to include it with your check-in so your family knows you're safe.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Wellvo uses your location to include it with your check-in so your family knows you're safe.</string>
 	<key>UIBackgroundModes</key>


### PR DESCRIPTION
Fixes App Store Connect warning 90683. Apple requires this key when the app references location APIs that can run in the background.

https://claude.ai/code/session_01YBzFAbEqtbSeqUHgjS1Pzo