### PR TITLE
Add "Link Apple ID" flow in account settings

### DIFF
--- a/edge-functions/functions/link-apple-id/index.ts
+++ b/edge-functions/functions/link-apple-id/index.ts
@@ -1,0 +1,131 @@
+import { supabaseAdmin } from "../../shared/supabase.ts";
+import type { AuthResult } from "../../shared/auth.ts";
+import { jwtVerify, createRemoteJWKSet } from "jose";
+
+interface LinkAppleIdRequest {
+  identity_token: string;
+  nonce: string;
+}
+
+const APPLE_ISSUER = "https://appleid.apple.com";
+const APPLE_JWKS_URI = "https://appleid.apple.com/auth/keys";
+const APP_BUNDLE_ID = Deno.env.get("APPLE_BUNDLE_ID") || "com.wellvo.ios";
+
+// jose handles key rotation and caching internally
+const appleJWKS = createRemoteJWKSet(new URL(APPLE_JWKS_URI));
+
+/**
+ * Links an Apple identity to the currently authenticated user.
+ *
+ * Users who signed up with email or phone can link their Apple ID so that
+ * "Sign in with Apple" lands on the same account — even though Apple's
+ * private-relay email won't match the original account email.
+ */
+export async function handleLinkAppleId(
+  req: Request,
+  auth: AuthResult
+): Promise<Response> {
+  const headers = { "Content-Type": "application/json" };
+
+  if (!auth.userId) {
+    return new Response(
+      JSON.stringify({ error: "Authentication required" }),
+      { status: 401, headers }
+    );
+  }
+
+  // Parse request
+  let body: LinkAppleIdRequest;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(
+      JSON.stringify({ error: "Invalid request body" }),
+      { status: 400, headers }
+    );
+  }
+
+  const { identity_token, nonce } = body;
+  if (!identity_token || !nonce) {
+    return new Response(
+      JSON.stringify({ error: "identity_token and nonce are required" }),
+      { status: 400, headers }
+    );
+  }
+
+  // Verify the Apple identity token (signature, issuer, audience, expiry)
+  let appleSub: string;
+  let appleEmail: string | undefined;
+  try {
+    const { payload } = await jwtVerify(identity_token, appleJWKS, {
+      issuer: APPLE_ISSUER,
+      audience: APP_BUNDLE_ID,
+    });
+
+    // Apple includes the SHA256-hashed nonce in the token; the client sends
+    // the same hash so we can compare directly.
+    if (!payload.nonce || payload.nonce !== nonce) {
+      return new Response(
+        JSON.stringify({ error: "Nonce mismatch" }),
+        { status: 400, headers }
+      );
+    }
+
+    appleSub = payload.sub as string;
+    appleEmail = payload.email as string | undefined;
+
+    if (!appleSub) {
+      return new Response(
+        JSON.stringify({ error: "Invalid Apple token: missing subject" }),
+        { status: 400, headers }
+      );
+    }
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Token verification failed";
+    return new Response(
+      JSON.stringify({ error: `Invalid Apple identity token: ${message}` }),
+      { status: 401, headers }
+    );
+  }
+
+  // Link the identity via the database function (handles duplicate checks,
+  // inserts into auth.identities, and updates app_metadata).
+  const identityData = {
+    sub: appleSub,
+    email: appleEmail,
+    email_verified: true,
+    iss: APPLE_ISSUER,
+    provider_id: appleSub,
+  };
+
+  const { error: linkError } = await supabaseAdmin.rpc("link_apple_identity", {
+    p_user_id: auth.userId,
+    p_provider_id: appleSub,
+    p_identity_data: identityData,
+  });
+
+  if (linkError) {
+    // The RPC raises specific exceptions for known cases
+    if (linkError.message?.includes("already linked")) {
+      return new Response(
+        JSON.stringify({ error: "This Apple ID is already linked to an account" }),
+        { status: 409, headers }
+      );
+    }
+    console.error("[link-apple-id] RPC error:", linkError.message);
+    return new Response(
+      JSON.stringify({ error: "Failed to link Apple ID" }),
+      { status: 500, headers }
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      success: true,
+      message: "Apple ID linked successfully",
+      apple_email: appleEmail,
+    }),
+    { headers }
+  );
+}

--- a/edge-functions/server.ts
+++ b/edge-functions/server.ts
@@ -25,6 +25,7 @@ import { handleReportLocation } from "./functions/report-location/index.ts";
 import { handleHeartbeat } from "./functions/heartbeat/index.ts";
 import { handleAutoJoin } from "./functions/auto-join/index.ts";
 import { handleRedeemCode } from "./functions/redeem-code/index.ts";
+import { handleLinkAppleId } from "./functions/link-apple-id/index.ts";
 
 type FunctionHandler = (req: Request, auth: AuthResult) => Promise<Response>;
 
@@ -48,6 +49,7 @@ const routes: Record<string, FunctionHandler> = {
   "/heartbeat": handleHeartbeat,
   "/auto-join": handleAutoJoin,
   "/redeem-code": handleRedeemCode,
+  "/link-apple-id": handleLinkAppleId,
 };
 
 const ALLOWED_ORIGIN = Deno.env.get("ALLOWED_ORIGIN") || "https://wellvo.net";

--- a/ios/Wellvo/Services/AuthService.swift
+++ b/ios/Wellvo/Services/AuthService.swift
@@ -111,6 +111,47 @@ actor AuthService {
         }
     }
 
+    // MARK: - Link Apple ID
+
+    /// Link an Apple identity to the currently signed-in user.
+    /// This allows users who signed up with email/phone to later use "Sign in with Apple."
+    func linkAppleID(credential: ASAuthorizationAppleIDCredential, rawNonce: String) async throws {
+        guard let identityToken = credential.identityToken,
+              let tokenString = String(data: identityToken, encoding: .utf8) else {
+            throw AuthError.invalidCredential
+        }
+
+        guard let session = try? await supabase.auth.session else {
+            throw AuthError.userNotFound
+        }
+
+        // Send the Apple identity token to our edge function which verifies it
+        // and links the identity in auth.identities via the admin API.
+        let hashedNonce = sha256(rawNonce)
+        try await supabase.functions.invoke(
+            "link-apple-id",
+            options: .init(body: [
+                "identity_token": tokenString,
+                "nonce": hashedNonce,
+            ])
+        )
+
+        // Persist the Apple user ID for revocation checks
+        persistAppleUserID(credential.user)
+    }
+
+    /// Check if the current user has an Apple identity linked.
+    func hasLinkedAppleID() async -> Bool {
+        guard let session = try? await supabase.auth.session else { return false }
+
+        let result: Bool? = try? await supabase
+            .rpc("has_apple_identity", params: ["p_user_id": session.user.id.uuidString])
+            .execute()
+            .value
+
+        return result ?? false
+    }
+
     // MARK: - Email Auth
 
     func signInWithEmail(email: String, password: String) async throws -> AppUser {

--- a/ios/Wellvo/ViewModels/AuthViewModel.swift
+++ b/ios/Wellvo/ViewModels/AuthViewModel.swift
@@ -28,7 +28,17 @@ final class AuthViewModel: ObservableObject {
     @Published var isAwaitingOTP = false
 
     /// The raw nonce generated for the current Apple Sign-In attempt.
-    private var currentRawNonce: String?
+    /// Backed by UserDefaults so it survives view recreation and SwiftUI lifecycle events.
+    private var currentRawNonce: String? {
+        get { UserDefaults.standard.string(forKey: "apple_signin_nonce") }
+        set {
+            if let newValue {
+                UserDefaults.standard.set(newValue, forKey: "apple_signin_nonce")
+            } else {
+                UserDefaults.standard.removeObject(forKey: "apple_signin_nonce")
+            }
+        }
+    }
 
     /// Supabase auth state listener handle
     private var authStateTask: Task<Void, Never>?
@@ -131,6 +141,7 @@ final class AuthViewModel: ObservableObject {
             }
             do {
                 currentUser = try await AuthService.shared.signInWithApple(credential: credential, rawNonce: rawNonce)
+                currentRawNonce = nil
                 authState = .authenticated
                 clearFormFields()
             } catch {
@@ -145,6 +156,60 @@ final class AuthViewModel: ObservableObject {
         }
 
         isLoading = false
+    }
+
+    // MARK: - Link Apple ID
+
+    @Published var hasLinkedApple = false
+    @Published var isLinkingApple = false
+    @Published var linkAppleMessage: String?
+
+    /// Check whether the current user already has a linked Apple identity.
+    func checkAppleLinkStatus() async {
+        hasLinkedApple = await AuthService.shared.hasLinkedAppleID()
+    }
+
+    /// Configure an Apple Sign-In request for identity linking (reuses nonce logic).
+    func configureAppleLinkRequest(_ request: ASAuthorizationAppleIDRequest) {
+        let rawNonce = Self.randomNonceString()
+        currentRawNonce = rawNonce
+        request.requestedScopes = [.email]
+        request.nonce = Self.sha256(rawNonce)
+    }
+
+    /// Handle the Apple Sign-In result for identity linking.
+    func linkAppleID(_ result: Result<ASAuthorization, Error>) async {
+        isLinkingApple = true
+        linkAppleMessage = nil
+
+        switch result {
+        case .success(let authorization):
+            guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+                linkAppleMessage = "Invalid Apple credential"
+                isLinkingApple = false
+                return
+            }
+            guard let rawNonce = currentRawNonce else {
+                linkAppleMessage = "Security check failed. Please try again."
+                isLinkingApple = false
+                return
+            }
+            do {
+                try await AuthService.shared.linkAppleID(credential: credential, rawNonce: rawNonce)
+                currentRawNonce = nil
+                hasLinkedApple = true
+                linkAppleMessage = "Apple ID linked successfully!"
+            } catch {
+                linkAppleMessage = error.localizedDescription
+            }
+
+        case .failure(let error):
+            if (error as? ASAuthorizationError)?.code != .canceled {
+                linkAppleMessage = error.localizedDescription
+            }
+        }
+
+        isLinkingApple = false
     }
 
     // MARK: - Email Auth

--- a/ios/Wellvo/Views/Settings/SettingsView.swift
+++ b/ios/Wellvo/Views/Settings/SettingsView.swift
@@ -1,9 +1,11 @@
 import SwiftUI
+import AuthenticationServices
 
 struct SettingsView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @EnvironmentObject var appState: AppState
     @StateObject private var subscriptionService = SubscriptionService.shared
+    @Environment(\.colorScheme) private var colorScheme
     @State private var showDeleteConfirmation = false
     @State private var isExportingData = false
     @State private var exportedData: String?
@@ -35,6 +37,44 @@ struct SettingsView: View {
                                     .foregroundStyle(.secondary)
                             }
                         }
+                    }
+                }
+
+                // Link Apple ID
+                Section {
+                    if authViewModel.hasLinkedApple {
+                        Label("Apple ID Linked", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                    } else {
+                        SignInWithAppleButton(.continue) { request in
+                            authViewModel.configureAppleLinkRequest(request)
+                        } onCompletion: { result in
+                            Task { await authViewModel.linkAppleID(result) }
+                        }
+                        .signInWithAppleButtonStyle(
+                            colorScheme == .dark ? .white : .black
+                        )
+                        .frame(height: 44)
+                        .disabled(authViewModel.isLinkingApple)
+
+                        if authViewModel.isLinkingApple {
+                            ProgressView()
+                                .frame(maxWidth: .infinity)
+                        }
+                    }
+
+                    if let message = authViewModel.linkAppleMessage {
+                        Text(message)
+                            .font(.caption)
+                            .foregroundStyle(
+                                authViewModel.hasLinkedApple ? .green : .red
+                            )
+                    }
+                } header: {
+                    Text("Apple ID")
+                } footer: {
+                    if !authViewModel.hasLinkedApple {
+                        Text("Link your Apple ID so you can use Sign in with Apple to access this account.")
                     }
                 }
 
@@ -124,6 +164,9 @@ struct SettingsView: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("This will permanently delete your account, your family group, all check-in history, and remove all members. This action cannot be undone.")
+            }
+            .task {
+                await authViewModel.checkAppleLinkStatus()
             }
             .sheet(isPresented: $showExportSheet) {
                 if let data = exportedData {

--- a/supabase/migrations/00017_link_apple_identity.sql
+++ b/supabase/migrations/00017_link_apple_identity.sql
@@ -1,0 +1,94 @@
+-- Migration: Add RPC function to link an Apple identity to an existing user
+-- This enables the "Link Apple ID" feature where users who signed up with
+-- email/phone can later link their Apple ID for Sign in with Apple.
+
+BEGIN;
+
+-- Function to safely insert an Apple identity into auth.identities.
+-- Called by the link-apple-id edge function with service role privileges.
+CREATE OR REPLACE FUNCTION public.link_apple_identity(
+    p_user_id UUID,
+    p_provider_id TEXT,
+    p_identity_data JSONB
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = auth, public
+AS $$
+BEGIN
+    -- Ensure the user exists in auth.users
+    IF NOT EXISTS (SELECT 1 FROM auth.users WHERE id = p_user_id) THEN
+        RAISE EXCEPTION 'User not found';
+    END IF;
+
+    -- Ensure this Apple ID isn't already linked to any user
+    IF EXISTS (
+        SELECT 1 FROM auth.identities
+        WHERE provider = 'apple' AND provider_id = p_provider_id
+    ) THEN
+        RAISE EXCEPTION 'Apple ID already linked to an account';
+    END IF;
+
+    -- Insert the identity record
+    INSERT INTO auth.identities (
+        id,
+        user_id,
+        provider,
+        provider_id,
+        identity_data,
+        last_sign_in_at,
+        created_at,
+        updated_at
+    ) VALUES (
+        gen_random_uuid(),
+        p_user_id,
+        'apple',
+        p_provider_id,
+        p_identity_data,
+        NOW(),
+        NOW(),
+        NOW()
+    );
+
+    -- Update the user's raw_app_meta_data to include apple in providers
+    UPDATE auth.users
+    SET raw_app_meta_data = raw_app_meta_data
+        || jsonb_build_object(
+            'providers',
+            CASE
+                WHEN raw_app_meta_data->'providers' IS NULL THEN '["apple"]'::jsonb
+                WHEN NOT (raw_app_meta_data->'providers' @> '"apple"') THEN
+                    (raw_app_meta_data->'providers') || '"apple"'::jsonb
+                ELSE raw_app_meta_data->'providers'
+            END
+        ),
+        updated_at = NOW()
+    WHERE id = p_user_id;
+END;
+$$;
+
+-- Only allow the service role (via edge functions) to call this
+REVOKE ALL ON FUNCTION public.link_apple_identity(UUID, TEXT, JSONB) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.link_apple_identity(UUID, TEXT, JSONB) FROM anon;
+REVOKE ALL ON FUNCTION public.link_apple_identity(UUID, TEXT, JSONB) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.link_apple_identity(UUID, TEXT, JSONB) TO service_role;
+
+-- Helper function to check if a user has an Apple identity linked
+CREATE OR REPLACE FUNCTION public.has_apple_identity(p_user_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = auth, public
+AS $$
+BEGIN
+    RETURN EXISTS (
+        SELECT 1 FROM auth.identities
+        WHERE user_id = p_user_id AND provider = 'apple'
+    );
+END;
+$$;
+
+-- Allow authenticated users to check their own Apple link status
+GRANT EXECUTE ON FUNCTION public.has_apple_identity(UUID) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- **Edge function (`link-apple-id`)**: Verifies the Apple identity token using Apple's JWKS, checks the nonce, then links the Apple identity to the authenticated user via a new database RPC
- **Migration (`00017`)**: Adds `link_apple_identity` RPC that safely inserts into `auth.identities` and updates `raw_app_meta_data` providers; also adds `has_apple_identity` helper for checking link status
- **iOS AuthService/ViewModel**: New `linkAppleID()` and `hasLinkedAppleID()` methods with a full linking flow in the view model
- **SettingsView**: New "Apple ID" section showing a `SignInWithAppleButton` when unlinked, or a green checkmark when already linked
- **Nonce resilience fix**: Raw nonce is now persisted in `UserDefaults` so it survives SwiftUI view recreation and lifecycle events (previously stored only in memory on the view model)

## Test plan

- [ ] Sign in with email/phone, open Settings, verify "Apple ID" section appears with the link button
- [ ] Tap "Continue with Apple", complete Apple Sign-In, verify success message and checkmark appears
- [ ] Sign out, sign back in with Apple — verify it lands on the same account
- [ ] Verify linking an Apple ID already used by another account returns a 409 conflict error
- [ ] Verify the nonce persists across view recreation (e.g., backgrounding the app during Apple Sign-In)
- [ ] Run migration `00017` and verify `link_apple_identity` and `has_apple_identity` functions exist
- [ ] Verify the edge function rejects invalid/expired Apple tokens

https://claude.ai/code/session_018rK16HmftbeeFAvHGEcV2K