### PR TITLE
Fix iOS build: add new files to Xcode project and extract PasswordStr…

### DIFF
--- a/ios/Wellvo.xcodeproj/project.pbxproj
+++ b/ios/Wellvo.xcodeproj/project.pbxproj
@@ -70,6 +70,14 @@
 		/* New Services */
 		B1C00009 /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C00009; };
 		B1C0000A /* HeartbeatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C0000A; };
+		B1C0000B /* BiometricService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C0000B; };
+		B1C0000C /* CertificatePinningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C0000C; };
+		/* Utilities */
+		B1D00004 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D00004; };
+		/* Views/Components */
+		B1F00012 /* SkeletonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F00012; };
+		/* Views/Auth */
+		B1F00013 /* PasswordStrength.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F00013; };
 		/* UI Tests */
 		B2U00001 /* WellvoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2U00001; };
 		B2U00002 /* OwnerFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2U00002; };
@@ -101,10 +109,13 @@
 		F1C00008 /* SupabaseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseService.swift; sourceTree = "<group>"; };
 		F1C00009 /* LocationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 		F1C0000A /* HeartbeatService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeartbeatService.swift; sourceTree = "<group>"; };
+		F1C0000B /* BiometricService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricService.swift; sourceTree = "<group>"; };
+		F1C0000C /* CertificatePinningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatePinningService.swift; sourceTree = "<group>"; };
 		/* Utilities */
 		F1D00001 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		F1D00002 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
 		F1D00003 /* NetworkRetry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRetry.swift; sourceTree = "<group>"; };
+		F1D00004 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		/* ViewModels */
 		F1E00001 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		F1E00002 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
@@ -128,6 +139,8 @@
 		F1F0000D /* ReceiverSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiverSettingsView.swift; sourceTree = "<group>"; };
 		F1F0000E /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		F1F0000F /* ViewerTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewerTabView.swift; sourceTree = "<group>"; };
+		F1F00012 /* SkeletonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonView.swift; sourceTree = "<group>"; };
+		F1F00013 /* PasswordStrength.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordStrength.swift; sourceTree = "<group>"; };
 		/* Resources */
 		F1G00001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		/* Config */
@@ -253,6 +266,8 @@
 			children = (
 				F1C00001 /* AnalyticsService.swift */,
 				F1C00002 /* AuthService.swift */,
+				F1C0000B /* BiometricService.swift */,
+				F1C0000C /* CertificatePinningService.swift */,
 				F1C00003 /* CheckInService.swift */,
 				F1C00004 /* FamilyService.swift */,
 				F1C0000A /* HeartbeatService.swift */,
@@ -268,6 +283,7 @@
 		G1D00001 /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				F1D00004 /* Colors.swift */,
 				F1D00001 /* Configuration.swift */,
 				F1D00002 /* KeychainService.swift */,
 				F1D00003 /* NetworkRetry.swift */,
@@ -290,6 +306,7 @@
 			isa = PBXGroup;
 			children = (
 				G1F00002 /* Auth */,
+				G1F00008 /* Components */,
 				G1F00003 /* Onboarding */,
 				G1F00004 /* Owner */,
 				G1F00005 /* Receiver */,
@@ -303,8 +320,17 @@
 			isa = PBXGroup;
 			children = (
 				F1F00001 /* AuthView.swift */,
+				F1F00013 /* PasswordStrength.swift */,
 			);
 			path = Auth;
+			sourceTree = "<group>";
+		};
+		G1F00008 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				F1F00012 /* SkeletonView.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 		G1F00003 /* Onboarding */ = {
@@ -493,6 +519,11 @@
 				B1F0000F /* ViewerTabView.swift in Sources */,
 				B1C00009 /* LocationService.swift in Sources */,
 				B1C0000A /* HeartbeatService.swift in Sources */,
+				B1C0000B /* BiometricService.swift in Sources */,
+				B1C0000C /* CertificatePinningService.swift in Sources */,
+				B1D00004 /* Colors.swift in Sources */,
+				B1F00012 /* SkeletonView.swift in Sources */,
+				B1F00013 /* PasswordStrength.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Wellvo/Views/Auth/AuthView.swift
+++ b/ios/Wellvo/Views/Auth/AuthView.swift
@@ -1,73 +1,6 @@
 import SwiftUI
 import AuthenticationServices
 
-// MARK: - Password Strength
-
-enum PasswordStrength: Int, Comparable {
-    case weak = 0, fair, good, strong
-
-    static func < (lhs: PasswordStrength, rhs: PasswordStrength) -> Bool {
-        lhs.rawValue < rhs.rawValue
-    }
-
-    var label: String {
-        switch self {
-        case .weak: return "Weak"
-        case .fair: return "Fair"
-        case .good: return "Good"
-        case .strong: return "Strong"
-        }
-    }
-
-    var color: Color {
-        switch self {
-        case .weak: return .red
-        case .fair: return .orange
-        case .good: return .yellow
-        case .strong: return .green
-        }
-    }
-
-    var progress: Double {
-        switch self {
-        case .weak: return 0.25
-        case .fair: return 0.5
-        case .good: return 0.75
-        case .strong: return 1.0
-        }
-    }
-
-    static func evaluate(_ password: String) -> PasswordStrength {
-        guard !password.isEmpty else { return .weak }
-
-        var score = 0
-
-        // Length
-        if password.count >= 10 { score += 1 }
-        if password.count >= 14 { score += 1 }
-
-        // Character diversity
-        if password.contains(where: { $0.isUppercase }) { score += 1 }
-        if password.contains(where: { $0.isLowercase }) { score += 1 }
-        if password.contains(where: { $0.isNumber }) { score += 1 }
-        if password.contains(where: { !$0.isLetter && !$0.isNumber }) { score += 1 }
-
-        // Penalty for common patterns
-        let commonPasswords: Set<String> = [
-            "password", "123456789", "1234567890", "qwerty1234", "iloveyou1",
-            "password1", "password12", "password123",
-        ]
-        if commonPasswords.contains(password.lowercased()) { return .weak }
-
-        switch score {
-        case 0...2: return .weak
-        case 3: return .fair
-        case 4...5: return .good
-        default: return .strong
-        }
-    }
-}
-
 struct AuthView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @EnvironmentObject var appState: AppState
@@ -287,29 +220,8 @@ struct AuthView: View {
                 }
 
             if isSignUp {
-                // Password strength indicator
                 if !authViewModel.password.isEmpty {
-                    let strength = PasswordStrength.evaluate(authViewModel.password)
-                    VStack(spacing: 4) {
-                        GeometryReader { geo in
-                            ZStack(alignment: .leading) {
-                                RoundedRectangle(cornerRadius: 2)
-                                    .fill(Color.gray.opacity(0.2))
-                                    .frame(height: 4)
-                                RoundedRectangle(cornerRadius: 2)
-                                    .fill(strength.color)
-                                    .frame(width: geo.size.width * strength.progress, height: 4)
-                                    .animation(.easeInOut(duration: 0.2), value: strength)
-                            }
-                        }
-                        .frame(height: 4)
-                        HStack {
-                            Text(strength.label)
-                                .font(.caption2)
-                                .foregroundStyle(strength.color)
-                            Spacer()
-                        }
-                    }
+                    PasswordStrengthIndicator(password: authViewModel.password)
                 }
 
                 Text("Password must be 10+ characters with uppercase, lowercase, and a number.")

--- a/ios/Wellvo/Views/Auth/PasswordStrength.swift
+++ b/ios/Wellvo/Views/Auth/PasswordStrength.swift
@@ -1,0 +1,98 @@
+import SwiftUI
+
+// MARK: - Password Strength
+
+enum PasswordStrength: Int, Comparable {
+    case weak = 0, fair, good, strong
+
+    static func < (lhs: PasswordStrength, rhs: PasswordStrength) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    var label: String {
+        switch self {
+        case .weak: return "Weak"
+        case .fair: return "Fair"
+        case .good: return "Good"
+        case .strong: return "Strong"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .weak: return .red
+        case .fair: return .orange
+        case .good: return .yellow
+        case .strong: return .green
+        }
+    }
+
+    var progress: Double {
+        switch self {
+        case .weak: return 0.25
+        case .fair: return 0.5
+        case .good: return 0.75
+        case .strong: return 1.0
+        }
+    }
+
+    static func evaluate(_ password: String) -> PasswordStrength {
+        guard !password.isEmpty else { return .weak }
+
+        var score = 0
+
+        // Length
+        if password.count >= 10 { score += 1 }
+        if password.count >= 14 { score += 1 }
+
+        // Character diversity
+        if password.contains(where: { $0.isUppercase }) { score += 1 }
+        if password.contains(where: { $0.isLowercase }) { score += 1 }
+        if password.contains(where: { $0.isNumber }) { score += 1 }
+        if password.contains(where: { !$0.isLetter && !$0.isNumber }) { score += 1 }
+
+        // Penalty for common patterns
+        let commonPasswords: Set<String> = [
+            "password", "123456789", "1234567890", "qwerty1234", "iloveyou1",
+            "password1", "password12", "password123",
+        ]
+        if commonPasswords.contains(password.lowercased()) { return .weak }
+
+        switch score {
+        case 0...2: return .weak
+        case 3: return .fair
+        case 4...5: return .good
+        default: return .strong
+        }
+    }
+}
+
+// MARK: - Password Strength Indicator View
+
+struct PasswordStrengthIndicator: View {
+    let password: String
+
+    var body: some View {
+        let strength = PasswordStrength.evaluate(password)
+        VStack(spacing: 4) {
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(Color.gray.opacity(0.2))
+                        .frame(height: 4)
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(strength.color)
+                        .frame(width: geo.size.width * strength.progress, height: 4)
+                        .animation(.easeInOut(duration: 0.2), value: strength)
+                }
+            }
+            .frame(height: 4)
+            HStack {
+                Text(strength.label)
+                    .font(.caption2)
+                    .foregroundStyle(strength.color)
+                Spacer()
+            }
+        }
+    }
+}


### PR DESCRIPTION
…ength

- Register BiometricService.swift, CertificatePinningService.swift, SkeletonView.swift, and Colors.swift in project.pbxproj so Xcode compiles them (fixes 'cannot find in scope' errors)
- Extract PasswordStrength enum from AuthView.swift into its own file to fix Swift type-checker timeout on the overly complex view body
- Add Components group under Views in Xcode project structure

https://claude.ai/code/session_016Hh5mNCfMYDvdFahymkrXB