### PR TITLE
fix(sync): wire owner dashboard to receiver check-ins end-to-end

### DIFF
--- a/android/app/src/main/java/net/dailyok/android/ui/screens/owner/DashboardScreen.kt
+++ b/android/app/src/main/java/net/dailyok/android/ui/screens/owner/DashboardScreen.kt
@@ -53,11 +53,15 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -149,6 +153,21 @@ fun DashboardScreen(
 
     LaunchedEffect(userId) {
         viewModel.loadDashboard(userId)
+    }
+
+    // Reload the dashboard whenever the app returns to the foreground or the
+    // user navigates back to this tab. Realtime should catch most updates, but
+    // this is a cheap fallback that guarantees the owner sees the latest state
+    // without needing to pull-to-refresh.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner, userId) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.loadDashboard(userId)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
     LaunchedEffect(errorMessage) {

--- a/android/app/src/main/java/net/dailyok/android/viewmodels/DashboardViewModel.kt
+++ b/android/app/src/main/java/net/dailyok/android/viewmodels/DashboardViewModel.kt
@@ -248,17 +248,34 @@ class DashboardViewModel @Inject constructor(
         }
 
         try {
-            val channel = supabase.channel("checkins:$familyId")
+            val channel = supabase.channel("owner-dashboard:$familyId")
 
-            val changeFlow = channel.postgresChangeFlow<PostgresAction>(schema = "public") {
+            // Three flows — one per table. `checkin_requests` is what tracks
+            // the Pending → Checked-In transition on the server, so we must
+            // listen there to flip the owner dashboard reactively. `alerts`
+            // covers urgent / pattern banners.
+            val checkinsFlow = channel.postgresChangeFlow<PostgresAction>(schema = "public") {
                 table = "checkins"
                 filter = "family_id=eq.$familyId"
             }
+            val requestsFlow = channel.postgresChangeFlow<PostgresAction>(schema = "public") {
+                table = "checkin_requests"
+                filter = "family_id=eq.$familyId"
+            }
+            val alertsFlow = channel.postgresChangeFlow<PostgresAction>(schema = "public") {
+                table = "alerts"
+                filter = "family_id=eq.$familyId"
+            }
 
-            realtimeJob = changeFlow.onEach {
-                // On any change (INSERT, UPDATE, DELETE), reload the dashboard
+            val reload: () -> Unit = {
                 currentUserId?.let { userId -> loadDashboard(userId) }
-            }.launchIn(viewModelScope)
+            }
+
+            realtimeJob = viewModelScope.launch {
+                launch { checkinsFlow.onEach { reload() }.launchIn(this) }
+                launch { requestsFlow.onEach { reload() }.launchIn(this) }
+                launch { alertsFlow.onEach { reload() }.launchIn(this) }
+            }
 
             channel.subscribe()
             realtimeChannel = channel

--- a/ios/DailyOK/Services/OfflineCheckInService.swift
+++ b/ios/DailyOK/Services/OfflineCheckInService.swift
@@ -107,6 +107,23 @@ final class OfflineCheckInService: ObservableObject {
                     .insert(payload)
                     .execute()
 
+                // Clear any still-pending check-in requests for this receiver+family
+                // so the owner dashboard stops showing "Pending" once the queued
+                // check-in syncs. The normal (online) path does this inside the
+                // `process-checkin-response` edge function; the direct-insert
+                // offline path has to do it here.
+                let nowISO = ISO8601DateFormatter().string(from: Date())
+                try? await SupabaseService.shared.client
+                    .from("checkin_requests")
+                    .update([
+                        "status": "checked_in",
+                        "responded_at": nowISO,
+                    ])
+                    .eq("receiver_id", value: offlineCheckIn.receiverId.uuidString)
+                    .eq("family_id", value: offlineCheckIn.familyId.uuidString)
+                    .eq("status", value: "pending")
+                    .execute()
+
                 offlineCheckIn.synced = true
                 try context.save()
             } catch {

--- a/ios/DailyOK/ViewModels/DashboardViewModel.swift
+++ b/ios/DailyOK/ViewModels/DashboardViewModel.swift
@@ -68,6 +68,9 @@ final class DashboardViewModel: ObservableObject {
     @Published var errorMessage: String?
 
     private var realtimeChannel: RealtimeChannelV2?
+    private var realtimeFamilyId: UUID?
+    private var realtimeListenerTask: Task<Void, Never>?
+    private var pendingRefreshTask: Task<Void, Never>?
 
     func loadDashboard() async {
         isLoading = true
@@ -261,25 +264,88 @@ final class DashboardViewModel: ObservableObject {
         )
     }
 
+    /// Subscribe to realtime changes on the three tables that drive the owner UI:
+    ///   - `checkins`          — new "I'm OK" responses flip Pending → Checked In
+    ///   - `checkin_requests`  — status transitions (pending → checked_in / missed)
+    ///   - `alerts`            — urgent / pattern alerts show in the banner
+    ///
+    /// The subscription is gated by `family_id` so each owner only receives their
+    /// own family's events. Duplicate reloads are debounced (250 ms) so a burst of
+    /// events (e.g. edge function inserts a checkin AND updates the request row)
+    /// triggers a single refresh.
     private func subscribeToRealtime(familyId: UUID) async {
-        let channel = SupabaseService.shared.client.realtimeV2.channel("checkins:\(familyId.uuidString)")
+        // Skip if we're already subscribed to this family
+        if realtimeFamilyId == familyId, realtimeChannel != nil {
+            return
+        }
 
-        let changes = channel.postgresChange(
+        // Tear down any prior subscription (family switch, sign-out/sign-in, etc.)
+        await teardownRealtime()
+
+        let client = SupabaseService.shared.client
+        let channel = client.realtimeV2.channel("owner-dashboard:\(familyId.uuidString)")
+
+        let checkinChanges = channel.postgresChange(
             AnyAction.self,
             schema: "public",
             table: "checkins",
             filter: "family_id=eq.\(familyId.uuidString)"
         )
 
+        let requestChanges = channel.postgresChange(
+            AnyAction.self,
+            schema: "public",
+            table: "checkin_requests",
+            filter: "family_id=eq.\(familyId.uuidString)"
+        )
+
+        let alertChanges = channel.postgresChange(
+            AnyAction.self,
+            schema: "public",
+            table: "alerts",
+            filter: "family_id=eq.\(familyId.uuidString)"
+        )
+
         await channel.subscribe()
 
-        Task {
-            for await _ in changes {
-                await loadDashboard()
+        realtimeListenerTask = Task { [weak self] in
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { [weak self] in
+                    for await _ in checkinChanges { await self?.scheduleRefresh() }
+                }
+                group.addTask { [weak self] in
+                    for await _ in requestChanges { await self?.scheduleRefresh() }
+                }
+                group.addTask { [weak self] in
+                    for await _ in alertChanges { await self?.scheduleRefresh() }
+                }
             }
         }
 
         realtimeChannel = channel
+        realtimeFamilyId = familyId
+    }
+
+    /// Debounced reload — coalesces bursts of realtime events into one reload.
+    private func scheduleRefresh() {
+        pendingRefreshTask?.cancel()
+        pendingRefreshTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 250_000_000) // 250 ms
+            guard !Task.isCancelled else { return }
+            await self?.loadDashboard()
+        }
+    }
+
+    private func teardownRealtime() async {
+        realtimeListenerTask?.cancel()
+        realtimeListenerTask = nil
+        pendingRefreshTask?.cancel()
+        pendingRefreshTask = nil
+        if let channel = realtimeChannel {
+            await channel.unsubscribe()
+        }
+        realtimeChannel = nil
+        realtimeFamilyId = nil
     }
 }
 

--- a/ios/DailyOK/Views/Owner/DashboardView.swift
+++ b/ios/DailyOK/Views/Owner/DashboardView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct DashboardView: View {
     @StateObject private var viewModel = DashboardViewModel()
     @State private var notificationBanner = NotificationPermissionBanner()
+    @EnvironmentObject var appState: AppState
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         NavigationStack {
@@ -77,6 +79,22 @@ struct DashboardView: View {
             .navigationTitle("Dashboard")
             .refreshable { await viewModel.loadDashboard() }
             .task { await viewModel.loadDashboard() }
+            // Reload when the app is brought back to the foreground so the owner
+            // sees check-ins that landed while the app was suspended (e.g. the
+            // receiver tapped "I'm OK" on another device).
+            .onChange(of: scenePhase) { _, newPhase in
+                if newPhase == .active {
+                    Task { await viewModel.loadDashboard() }
+                }
+            }
+            // Reload when the owner navigates back to the Dashboard tab after
+            // visiting another tab. SwiftUI keeps tabs alive, so `.task` only
+            // fires once per view lifetime — `onChange` covers the rest.
+            .onChange(of: appState.selectedTab) { _, newTab in
+                if newTab == .dashboard {
+                    Task { await viewModel.loadDashboard() }
+                }
+            }
         }
     }
 

--- a/ios/DailyOK/Views/Receiver/ReceiverHomeView.swift
+++ b/ios/DailyOK/Views/Receiver/ReceiverHomeView.swift
@@ -4,6 +4,7 @@ struct ReceiverHomeView: View {
     @StateObject private var viewModel = ReceiverViewModel()
     @EnvironmentObject var authViewModel: AuthViewModel
     @Environment(\.accessibilityReduceMotion) var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
     @State private var buttonScale: CGFloat = 1.0
     @State private var isPulsing = false
     @State private var showCheckmark = false
@@ -96,6 +97,14 @@ struct ReceiverHomeView: View {
             }
         }
         .task { await viewModel.loadStatus() }
+        // If a silent push request arrived while the app was backgrounded, or the
+        // user checked in on another device, re-fetch on foreground so the home
+        // screen reflects the true state instead of stale "please check in" UI.
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                Task { await viewModel.loadStatus() }
+            }
+        }
         .alert("Sign Out", isPresented: $showSignOutConfirmation) {
             Button("Sign Out", role: .destructive) {
                 Task { await authViewModel.signOut() }

--- a/supabase/migrations/00020_realtime_publications.sql
+++ b/supabase/migrations/00020_realtime_publications.sql
@@ -1,0 +1,103 @@
+-- Daily OK: Enable Supabase Realtime for check-in sync tables
+-- Migration: 00020_realtime_publications
+--
+-- Root cause: the Owner dashboard subscribes to `checkins` (and should subscribe
+-- to `checkin_requests` / `alerts`) via the Supabase Realtime client. However,
+-- these tables were never added to the `supabase_realtime` publication, so
+-- Postgres never streamed changes to the Realtime server. The owner UI would
+-- stay on "Pending" indefinitely even after the receiver tapped "I'm OK".
+--
+-- This migration:
+--   1. Ensures the `supabase_realtime` publication exists (defensive — self-hosted
+--      Supabase usually pre-creates it, but local bootstraps may not).
+--   2. Adds the three tables that drive the owner UI to the publication.
+--   3. Sets REPLICA IDENTITY FULL so UPDATE / DELETE events carry full rows
+--      (required for client-side filters like `family_id=eq.<uuid>` to match
+--      on UPDATE events, since the default replica identity only ships the PK).
+--
+-- Safe to re-run: uses existence checks before ALTER PUBLICATION / REPLICA IDENTITY.
+
+BEGIN;
+
+-- 1. Ensure publication exists
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = 'supabase_realtime') THEN
+        CREATE PUBLICATION supabase_realtime;
+    END IF;
+END $$;
+
+-- 2. Add tables to publication (idempotent — skip if already a member)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_publication_tables
+        WHERE pubname = 'supabase_realtime'
+          AND schemaname = 'public'
+          AND tablename  = 'checkins'
+    ) THEN
+        ALTER PUBLICATION supabase_realtime ADD TABLE public.checkins;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_publication_tables
+        WHERE pubname = 'supabase_realtime'
+          AND schemaname = 'public'
+          AND tablename  = 'checkin_requests'
+    ) THEN
+        ALTER PUBLICATION supabase_realtime ADD TABLE public.checkin_requests;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_publication_tables
+        WHERE pubname = 'supabase_realtime'
+          AND schemaname = 'public'
+          AND tablename  = 'alerts'
+    ) THEN
+        ALTER PUBLICATION supabase_realtime ADD TABLE public.alerts;
+    END IF;
+END $$;
+
+-- 3. Replica identity — ship full rows so RLS + filters work on UPDATE/DELETE.
+-- FULL is slightly more WAL-heavy than DEFAULT, but these tables are low-volume
+-- (a few rows per user per day), so the cost is negligible.
+ALTER TABLE public.checkins          REPLICA IDENTITY FULL;
+ALTER TABLE public.checkin_requests  REPLICA IDENTITY FULL;
+ALTER TABLE public.alerts            REPLICA IDENTITY FULL;
+
+-- 4. Allow receivers to resolve their own pending check-in requests.
+--
+-- The `process-checkin-response` edge function (service role) already flips
+-- `checkin_requests.status` from `pending` to `checked_in` when the receiver
+-- taps "I'm OK" online. When the tap happens offline, the iOS / Android offline
+-- queue inserts the checkin directly via RLS — but without this policy the
+-- queued sync can't close out the matching request row, leaving the owner
+-- dashboard stuck on "Pending" even after the check-in lands.
+--
+-- Policy is intentionally narrow:
+--   * Receivers can only UPDATE rows where they are the `receiver_id`.
+--   * The USING + WITH CHECK pair restricts changes to rows they already own.
+-- The edge function keeps authoring all OTHER transitions (expired, missed)
+-- under the service role, so the surface area stays small.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename  = 'checkin_requests'
+          AND policyname = 'Receivers can resolve own requests'
+    ) THEN
+        CREATE POLICY "Receivers can resolve own requests"
+            ON public.checkin_requests
+            FOR UPDATE
+            USING (receiver_id = auth.uid())
+            WITH CHECK (receiver_id = auth.uid());
+    END IF;
+END $$;
+
+COMMIT;
+
+-- Verification query (for manual post-migration check):
+--   SELECT schemaname, tablename FROM pg_publication_tables
+--   WHERE pubname = 'supabase_realtime' ORDER BY tablename;
+-- Expected rows: public.alerts, public.checkin_requests, public.checkins


### PR DESCRIPTION
Root cause: the `checkins`, `checkin_requests`, and `alerts` tables were
never added to the `supabase_realtime` publication on the self-hosted
Supabase instance. The iOS and Android owner dashboards subscribed to
realtime changes, but Postgres never streamed the events, so the UI
stayed on "Pending" indefinitely after a receiver tapped "I'm OK".

Fixes the full loop so the owner sees the check-in immediately without
pull-to-refresh, and falls back to smart reloads if realtime is
temporarily unavailable.

Changes:
- Migration 00020: add public.checkins, public.checkin_requests, and
  public.alerts to the `supabase_realtime` publication and set
  REPLICA IDENTITY FULL so UPDATE/DELETE events carry filterable rows.
- Migration 00020: add a narrow RLS policy letting receivers UPDATE
  their own `checkin_requests` so the offline-sync path can mark
  pending requests as checked_in (the online path already does this
  via the `process-checkin-response` edge function's service role).
- iOS DashboardViewModel: subscribe to all three tables on one channel,
  debounce reload to 250 ms, skip resubscribing to the same family,
  and add explicit teardown for sign-out / family-switch.
- iOS DashboardView: reload on scenePhase.active and on tab change
  back to Dashboard. `.task` only fires once per view lifetime.
- iOS ReceiverHomeView: reload status on scenePhase.active so stale
  "please check in" UI updates after a background sync.
- iOS OfflineCheckInService: after direct-inserting a queued check-in,
  also mark any matching pending checkin_requests as checked_in so the
  owner stops seeing "Pending" once the queue drains.
- Android DashboardViewModel: mirror iOS — subscribe to checkins,
  checkin_requests, and alerts on a single realtime channel.
- Android DashboardScreen: reload on ON_RESUME via LifecycleEventObserver
  so foreground returns refresh the dashboard.

https://claude.ai/code/session_01FLSXgBgVjZWBT3abXafWnB