### PR TITLE
Support manual check-ins without pending requests

### DIFF
--- a/android/app/src/main/java/net/dailyok/android/network/ApiService.kt
+++ b/android/app/src/main/java/net/dailyok/android/network/ApiService.kt
@@ -15,7 +15,9 @@ import javax.inject.Singleton
 
 @Serializable
 data class CheckInResponseRequest(
-    val requestId: String,
+    val requestId: String? = null,
+    val receiverId: String? = null,
+    val familyId: String? = null,
     val mood: String? = null,
     val source: String = "app",
     val latitude: Double? = null,
@@ -128,8 +130,13 @@ class ApiService @Inject constructor(
     }
 
     suspend fun processCheckinResponse(request: CheckInResponseRequest): String {
+        // The edge function accepts either `checkin_request_id` (notification
+        // response path) or `receiver_id` + `family_id` (manual check-in
+        // without a pending request). Send whichever the caller provided.
         return invokeFunction("process-checkin-response", buildJsonObject {
-            put("request_id", request.requestId)
+            request.requestId?.let { put("checkin_request_id", it) }
+            request.receiverId?.let { put("receiver_id", it) }
+            request.familyId?.let { put("family_id", it) }
             request.mood?.let { put("mood", it) }
             put("source", request.source)
             request.latitude?.let { put("latitude", it) }
@@ -148,7 +155,7 @@ class ApiService @Inject constructor(
 
     suspend fun confirmDelivery(request: ConfirmDeliveryRequest): String {
         return invokeFunction("confirm-delivery", buildJsonObject {
-            put("request_id", request.requestId)
+            put("checkin_request_id", request.requestId)
         })
     }
 

--- a/android/app/src/main/java/net/dailyok/android/services/CheckInService.kt
+++ b/android/app/src/main/java/net/dailyok/android/services/CheckInService.kt
@@ -28,7 +28,7 @@ class CheckInService @Inject constructor(
     suspend fun checkIn(
         familyId: String,
         receiverId: String,
-        requestId: String,
+        requestId: String?,
         mood: String? = null,
         source: String = "app",
         latitude: Double? = null,
@@ -37,9 +37,15 @@ class CheckInService @Inject constructor(
         kidResponseType: String? = null
     ): String {
         try {
+            // Pass both the request id (if responding to a scheduled/on-demand
+            // notification) and the receiver/family ids (so the edge function
+            // can still record the check-in when there's no pending request,
+            // e.g. user tapped "I'm OK" manually outside a notification).
             return apiService.processCheckinResponse(
                 CheckInResponseRequest(
                     requestId = requestId,
+                    receiverId = receiverId,
+                    familyId = familyId,
                     mood = mood,
                     source = source,
                     latitude = latitude,
@@ -183,18 +189,55 @@ class CheckInService @Inject constructor(
         }
     }
 
+    /// Fetches check-ins for a family that fall within today's window. The
+    /// window must be wide enough to cover every receiver's local "today",
+    /// because receivers in different timezones have different day boundaries.
+    /// We query a 48-hour window (starting 24h before the owner's local
+    /// midnight) and let callers filter per-receiver using each receiver's
+    /// own timezone.
     suspend fun todayCheckInsForFamily(familyId: String): List<CheckIn> {
         try {
-            val today = LocalDate.now().format(DateTimeFormatter.ISO_LOCAL_DATE)
+            // Timezone offsets span roughly UTC-12 to UTC+14, so a receiver's
+            // "today" can start up to 14h before and end up to 12h after the
+            // owner's. A ±24h window around now is plenty to cover every
+            // family member's local day regardless of zone.
+            val now = java.time.Instant.now()
+            val windowStart = now.minus(Duration.ofHours(24))
+            val windowEnd = now.plus(Duration.ofHours(24))
+            val iso = DateTimeFormatter.ISO_INSTANT
             return supabase.postgrest.from("checkins")
                 .select {
                     filter { eq("family_id", familyId) }
-                    filter { gte("checked_in_at", "${today}T00:00:00") }
-                    filter { lt("checked_in_at", "${today}T23:59:59.999") }
+                    filter { gte("checked_in_at", iso.format(windowStart)) }
+                    filter { lt("checked_in_at", iso.format(windowEnd)) }
                 }
                 .decodeList<CheckIn>()
         } catch (e: Exception) {
             throw DailyOKError.Unknown(e.message ?: "Failed to fetch today's check-ins.")
+        }
+    }
+
+    /// True if `checkedInAtIso` falls within "today" in the given IANA
+    /// timezone. Used to filter the wide family-level query down to each
+    /// receiver's local day.
+    fun isWithinLocalToday(checkedInAtIso: String, timezone: String?): Boolean {
+        return try {
+            val zone = try {
+                timezone?.let { ZoneId.of(it) } ?: ZoneId.systemDefault()
+            } catch (_: Exception) { ZoneId.systemDefault() }
+            val instant = try {
+                java.time.OffsetDateTime.parse(checkedInAtIso).toInstant()
+            } catch (_: Exception) {
+                // Fall back to treating a bare local timestamp as UTC, which
+                // matches how Postgres timestamptz values are typically sent
+                // when the trailing offset is omitted.
+                java.time.Instant.parse("${checkedInAtIso.trimEnd('Z')}Z")
+            }
+            val localDate = instant.atZone(zone).toLocalDate()
+            val today = ZonedDateTime.now(zone).toLocalDate()
+            localDate == today
+        } catch (_: Exception) {
+            false
         }
     }
 

--- a/android/app/src/main/java/net/dailyok/android/services/OfflineCheckInService.kt
+++ b/android/app/src/main/java/net/dailyok/android/services/OfflineCheckInService.kt
@@ -74,7 +74,7 @@ class OfflineCheckInService @Inject constructor(
     suspend fun performCheckIn(
         familyId: String,
         receiverId: String,
-        requestId: String,
+        requestId: String? = null,
         mood: String? = null,
         source: String = "app"
     ): Boolean {
@@ -119,10 +119,14 @@ class OfflineCheckInService @Inject constructor(
         val unsynced = offlineCheckInDao.getUnsynced()
         for (checkIn in unsynced) {
             try {
+                // Intentionally pass requestId=null — the local row's UUID
+                // doesn't match any checkin_requests row on the server, so
+                // letting the edge function look up (or skip) via
+                // receiver_id + family_id is the correct path.
                 checkInService.checkIn(
                     familyId = checkIn.familyId,
                     receiverId = checkIn.receiverId,
-                    requestId = checkIn.id,
+                    requestId = null,
                     mood = checkIn.mood,
                     source = checkIn.source
                 )

--- a/android/app/src/main/java/net/dailyok/android/viewmodels/DashboardViewModel.kt
+++ b/android/app/src/main/java/net/dailyok/android/viewmodels/DashboardViewModel.kt
@@ -149,8 +149,16 @@ class DashboardViewModel @Inject constructor(
                     checkNotificationStatusBatch(receivers.map { it.userId })
                 } catch (_: Exception) { emptySet() }
 
-                // Group results by receiver for in-memory mapping
-                val todayByReceiver = todayCheckIns.groupBy { it.receiverId }
+                // Group results by receiver, then narrow "today" down to each
+                // receiver's local calendar day — the batched query uses a
+                // wide 48h window to cover all timezones, so we still need to
+                // filter per-receiver here.
+                val todayByReceiver = todayCheckIns
+                    .groupBy { it.receiverId }
+                    .mapValues { (receiverId, checkIns) ->
+                        val tz = receivers.firstOrNull { it.userId == receiverId }?.user?.timezone
+                        checkIns.filter { checkInService.isWithinLocalToday(it.checkedInAt, tz) }
+                    }
                 val historyByReceiver = allHistory.groupBy { it.receiverId }
                 val sevenDaysAgo = LocalDate.now().minusDays(7)
                     .format(DateTimeFormatter.ISO_LOCAL_DATE)

--- a/android/app/src/main/java/net/dailyok/android/viewmodels/ReceiverViewModel.kt
+++ b/android/app/src/main/java/net/dailyok/android/viewmodels/ReceiverViewModel.kt
@@ -97,7 +97,15 @@ class ReceiverViewModel @Inject constructor(
                     }
                     .decodeSingleOrNull<ReceiverSettings>()
 
-                val todayCheckIn = checkInService.todayCheckInStatus(userId, member.familyId)
+                // "Today" is the receiver's local day, not the device's, so a
+                // user who travelled to a different timezone (or mistakenly
+                // has a device TZ that disagrees with their profile) still
+                // sees the correct state.
+                val todayCheckIn = checkInService.todayCheckInStatus(
+                    userId,
+                    member.familyId,
+                    settings?.timezone
+                )
 
                 val pendingRequest = if (todayCheckIn == null) {
                     checkInService.getTodayPendingRequest(userId, member.familyId)
@@ -127,12 +135,10 @@ class ReceiverViewModel @Inject constructor(
         val state = _uiState.value
         val familyId = state.familyId ?: return
         val receiverId = state.receiverId ?: return
+        // `requestId` is optional — when the user taps "I'm OK" outside of a
+        // scheduled/on-demand notification there's no pending request row, so
+        // the edge function records the check-in via receiver_id+family_id.
         val requestId = state.pendingRequestId
-
-        if (requestId == null) {
-            _uiState.value = state.copy(errorMessage = "No pending check-in request.")
-            return
-        }
 
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isCheckingIn = true, errorMessage = null)
@@ -152,6 +158,7 @@ class ReceiverViewModel @Inject constructor(
                     isCheckingIn = false,
                     hasCheckedInToday = true,
                     lastCheckIn = updatedCheckIn,
+                    pendingRequestId = null,
                     showMoodSelector = true
                 )
             } catch (e: DailyOKError) {

--- a/android/app/src/test/java/net/dailyok/android/services/CheckInServiceTest.kt
+++ b/android/app/src/test/java/net/dailyok/android/services/CheckInServiceTest.kt
@@ -93,7 +93,7 @@ class CheckInServiceTest {
 
     // Mirrors CheckInService.checkIn logic
     private suspend fun checkInHelper(
-        familyId: String, receiverId: String, requestId: String,
+        familyId: String, receiverId: String, requestId: String?,
         mood: String?, source: String,
         latitude: Double? = null, longitude: Double? = null,
         locationAccuracy: Double? = null, kidResponseType: String? = null
@@ -101,7 +101,10 @@ class CheckInServiceTest {
         try {
             return apiService.processCheckinResponse(
                 CheckInResponseRequest(
-                    requestId = requestId, mood = mood, source = source,
+                    requestId = requestId,
+                    receiverId = receiverId,
+                    familyId = familyId,
+                    mood = mood, source = source,
                     latitude = latitude, longitude = longitude,
                     locationAccuracyMeters = locationAccuracy,
                     kidResponseType = kidResponseType

--- a/ios/DailyOK/Services/CheckInService.swift
+++ b/ios/DailyOK/Services/CheckInService.swift
@@ -122,6 +122,12 @@ actor CheckInService {
             calendar.timeZone = tz
         }
         let startOfDay = calendar.startOfDay(for: Date())
+        // Upper bound = start of tomorrow in the same timezone. Without this,
+        // a row with a future `checked_in_at` (e.g. server-side clock skew, or
+        // a legacy seed row) would satisfy the `gte` filter and be returned
+        // as "today's check-in" even when the receiver hasn't actually
+        // checked in.
+        let startOfTomorrow = calendar.date(byAdding: .day, value: 1, to: startOfDay) ?? startOfDay.addingTimeInterval(86_400)
         let formatter = ISO8601DateFormatter()
 
         let checkIns: [CheckIn] = try await supabase
@@ -130,6 +136,7 @@ actor CheckInService {
             .eq("receiver_id", value: receiverId.uuidString)
             .eq("family_id", value: familyId.uuidString)
             .gte("checked_in_at", value: formatter.string(from: startOfDay))
+            .lt("checked_in_at", value: formatter.string(from: startOfTomorrow))
             .order("checked_in_at", ascending: false)
             .limit(1)
             .execute()

--- a/ios/DailyOK/Services/OfflineCheckInService.swift
+++ b/ios/DailyOK/Services/OfflineCheckInService.swift
@@ -93,6 +93,8 @@ final class OfflineCheckInService: ObservableObject {
 
         guard let pending = try? context.fetch(descriptor), !pending.isEmpty else { return }
 
+        var syncedAny = false
+
         for offlineCheckIn in pending {
             do {
                 let payload = OfflineCheckInInsert(
@@ -126,6 +128,7 @@ final class OfflineCheckInService: ObservableObject {
 
                 offlineCheckIn.synced = true
                 try context.save()
+                syncedAny = true
             } catch {
                 print("[OfflineCheckInService] Sync failed for \(offlineCheckIn.id): \(error.localizedDescription)")
                 break // Stop on first failure, retry later
@@ -133,7 +136,16 @@ final class OfflineCheckInService: ObservableObject {
         }
 
         updatePendingCount()
+
+        // Let any view model observing sync completion (e.g. ReceiverHomeView,
+        // DashboardView) re-query status so the UI reflects the synced rows
+        // without waiting for the next scene-phase change.
+        if syncedAny {
+            NotificationCenter.default.post(name: OfflineCheckInService.didSyncCheckIns, object: nil)
+        }
     }
+
+    static let didSyncCheckIns = Notification.Name("OfflineCheckInService.didSyncCheckIns")
 
     // MARK: - Private
 

--- a/ios/DailyOK/ViewModels/ReceiverViewModel.swift
+++ b/ios/DailyOK/ViewModels/ReceiverViewModel.swift
@@ -31,18 +31,25 @@ final class ReceiverViewModel: ObservableObject {
             .execute()
             .value
 
-        if let todayCheckIn = try? await CheckInService.shared.todayCheckInStatus(
+        // Sync any queued offline check-ins first so the subsequent status
+        // query reflects them. Without this, a synced check-in would only
+        // appear after the next manual refresh.
+        await offlineService.syncPendingCheckIns()
+
+        // Reset state BEFORE the query so a stale `true` from yesterday
+        // doesn't bleed into today if the query returns nil. The `@StateObject`
+        // persists across scene phases, so without this reset the receiver
+        // sees "you're all set" indefinitely once they check in once.
+        let todayCheckIn = try? await CheckInService.shared.todayCheckInStatus(
             receiverId: session.user.id,
             familyId: family.id,
             timezone: tzRow?.timezone
-        ) {
-            lastCheckIn = todayCheckIn
-            hasCheckedInToday = true
-        }
+        )
+        lastCheckIn = todayCheckIn
+        hasCheckedInToday = (todayCheckIn != nil)
 
         await loadReceiverSettings(userId: session.user.id, familyId: family.id)
 
-        await offlineService.syncPendingCheckIns()
         isOffline = !offlineService.isOnline
         pendingOfflineCount = offlineService.pendingCount
     }
@@ -111,12 +118,17 @@ final class ReceiverViewModel: ObservableObject {
             hasCheckedInToday = true
             Task { await AnalyticsService.shared.track(.checkIn) }
         } catch let error as NetworkError {
+            // Offline path: the check-in is queued locally and will sync when
+            // connectivity returns. Show the success state optimistically.
             hasCheckedInToday = true
             isOffline = true
             Task { await AnalyticsService.shared.track(.checkInOffline) }
             pendingOfflineCount = offlineService.pendingCount
             errorMessage = error.localizedDescription
         } catch {
+            // Real failure (auth, server 5xx, etc): do NOT flip the UI to
+            // "checked in" — otherwise the receiver sees "you're all set"
+            // for a check-in that was never recorded.
             errorMessage = error.localizedDescription
         }
 

--- a/ios/DailyOK/Views/Owner/DashboardView.swift
+++ b/ios/DailyOK/Views/Owner/DashboardView.swift
@@ -107,6 +107,12 @@ struct DashboardView: View {
                     Task { await viewModel.loadDashboard() }
                 }
             }
+            // Reload when a queued offline check-in syncs (e.g. the owner is
+            // also a receiver on the same device) so the card flips from
+            // Pending to Checked In without waiting for the next foreground.
+            .onReceive(NotificationCenter.default.publisher(for: OfflineCheckInService.didSyncCheckIns)) { _ in
+                Task { await viewModel.loadDashboard() }
+            }
         }
     }
 

--- a/ios/DailyOK/Views/Receiver/ReceiverHomeView.swift
+++ b/ios/DailyOK/Views/Receiver/ReceiverHomeView.swift
@@ -124,6 +124,12 @@ struct ReceiverHomeView: View {
                 Task { await viewModel.loadStatus() }
             }
         }
+        // When queued offline check-ins sync to the server, reload so the
+        // "you're all set" card reflects the now-persisted check-in (or
+        // vice-versa if the server rejected it).
+        .onReceive(NotificationCenter.default.publisher(for: OfflineCheckInService.didSyncCheckIns)) { _ in
+            Task { await viewModel.loadStatus() }
+        }
         .alert("Sign Out", isPresented: $showSignOutConfirmation) {
             Button("Sign Out", role: .destructive) {
                 DailyOKHaptics.warning()


### PR DESCRIPTION
## Summary
This PR enables users to check in manually (e.g., by tapping "I'm OK" outside of a notification) without requiring a pending check-in request. It also improves timezone handling for "today" queries and fixes state management issues in offline sync scenarios.

## Key Changes

### Check-in Request ID is Now Optional
- Made `requestId` parameter optional in `CheckInService.checkIn()` (Android/iOS)
- Updated `CheckInResponseRequest` to include optional `receiverId` and `familyId` fields
- Modified API calls to send either `checkin_request_id` (notification response) or `receiver_id` + `family_id` (manual check-in) to the edge function
- Removed validation that rejected check-ins without a pending request ID

### Improved Timezone-Aware "Today" Queries
- **Android**: Changed `todayCheckInsForFamily()` to use a ±24-hour window around the current instant instead of a single calendar day, ensuring coverage across all timezones (UTC-12 to UTC+14)
- Added `isWithinLocalToday()` helper to filter results to each receiver's local calendar day
- Updated `DashboardViewModel` to apply per-receiver timezone filtering on the wide query results
- **iOS**: Added upper bound (`startOfTomorrow`) to `todayCheckInStatus()` query to prevent future-dated rows from being returned as today's check-in
- Updated `ReceiverViewModel` (Android) to pass receiver's timezone to `todayCheckInStatus()` for accurate local-day filtering

### Fixed State Management in Offline Sync
- **iOS**: Moved `offlineService.syncPendingCheckIns()` before the status query in `ReceiverViewModel.loadStatus()` so synced check-ins appear immediately
- Reset `hasCheckedInToday` state before querying to prevent stale `true` values from yesterday bleeding into today
- Added `didSyncCheckIns` notification that fires when offline check-ins sync, triggering UI refreshes in `ReceiverHomeView` and `DashboardView`
- **Android**: Added `pendingRequestId = null` to UI state after successful check-in to clear the pending request

### Offline Check-in Sync Improvements
- **Android**: Changed `OfflineCheckInService.syncPendingCheckIns()` to pass `requestId = null` when syncing local check-ins (since local UUIDs don't match server request rows)
- **iOS**: Added `syncedAny` flag and notification posting to notify observers when sync completes

## Notable Implementation Details
- The ±24-hour window approach is more robust than calendar-day queries for multi-timezone families, as it naturally covers all possible local "today" boundaries
- Manual check-ins are now routed through the same edge function as notification responses, with the function determining the path based on which identifiers are provided
- Offline sync now properly triggers UI updates via notifications rather than relying on scene-phase changes alone

https://claude.ai/code/session_01B3m9k7mHtcw1X7Zu6J1bxV