### PR TITLE
Add branching strategy, release flow, and backward compatibility rules

### DIFF
--- a/.github/rulesets/README.md
+++ b/.github/rulesets/README.md
@@ -1,0 +1,90 @@
+# GitHub Branch Rulesets
+
+Version-controlled definitions of the branch protection rulesets applied to `dj-pearson/wellvo`. Use these JSON files as the source of truth — apply them with `scripts/apply-rulesets.sh` rather than editing in the GitHub UI.
+
+## Why rulesets (not classic branch protection)
+
+GitHub rulesets are the modern replacement for "classic" branch protection rules. They support:
+
+- Pattern-based targets (`refs/heads/release/*`)
+- Multiple bypass actors with explicit modes
+- Versioning (each ruleset has an `id` and update history)
+- A clean REST API: `POST /repos/{owner}/{repo}/rulesets`
+
+We commit the JSON so the protection state is reproducible and reviewable.
+
+## Branch → protections
+
+| Ruleset                       | Targets                  | Deletion | Force-push | PR required          | Bypass             |
+| ----------------------------- | ------------------------ | -------- | ---------- | -------------------- | ------------------ |
+| `main-protection`             | `refs/heads/main`        | blocked  | blocked    | yes (0 approvals)    | Repo admin (always) |
+| `develop-protection`          | `refs/heads/develop`     | blocked  | blocked    | yes (0 approvals)    | Repo admin (always) |
+| `release-branches-protection` | `refs/heads/release/*`   | blocked  | blocked    | yes (0 approvals)    | Repo admin (always) |
+| `hotfix-branches-protection`  | `refs/heads/hotfix/*`    | blocked  | blocked    | **no** (direct commits allowed on the hotfix branch itself; the gate is the PR `hotfix/* → main`, enforced by `main-protection`) | Repo admin (always) |
+
+`required_approving_review_count: 0` is intentional for the current solo-developer setup — GitHub does not let the PR author approve their own PR, so requiring an approval would deadlock all merges. A PR is still required for `main`, `develop`, and `release/*`; the author just self-merges.
+
+**When a second reviewer joins**, bump `required_approving_review_count` from `0` to `1` in `main.json` and `release.json` and re-apply. Leave `develop.json` at 0 if you want low-friction integration merges.
+
+## Bypass actor
+
+```json
+{ "actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always" }
+```
+
+`actor_id: 5` is the well-known ID for the **Admin** repository role. `bypass_mode: "always"` means an admin (you) can override the ruleset without flipping it to "evaluate" mode first. This is the emergency-override escape hatch.
+
+## Apply / re-apply
+
+```bash
+# requires gh CLI authenticated against the repo, or a GITHUB_TOKEN with `repo` and `administration` scopes
+bash scripts/apply-rulesets.sh
+```
+
+The script does an idempotent **find by name → PUT if exists, POST if not** loop:
+
+1. `GET /repos/{owner}/{repo}/rulesets` — list all rulesets
+2. For each `.github/rulesets/*.json` (excluding `README.md`):
+   - Match by `name` field in the JSON
+   - If found: `PUT /repos/{owner}/{repo}/rulesets/{id}` with the JSON body
+   - If not found: `POST /repos/{owner}/{repo}/rulesets` with the JSON body
+
+This means you can re-run the script after any local edit and it will converge the remote state to match the JSON.
+
+## Adding required status checks (later)
+
+Required status check names that don't exist on a PR **block all merges**. Don't add them speculatively. The correct sequence:
+
+1. Open a real PR that triggers the workflows. Note the exact "check run" names that appear in the merge box (e.g. `build-and-test`, `api-integration-tests`).
+2. Add a `required_status_checks` rule to `main.json` (and optionally `release.json`):
+
+   ```json
+   {
+     "type": "required_status_checks",
+     "parameters": {
+       "strict_required_status_checks_policy": false,
+       "required_status_checks": [
+         {
+           "context": "build-and-test",
+           "integration_id": 15368
+         },
+         {
+           "context": "api-integration-tests",
+           "integration_id": 15368
+         }
+       ]
+     }
+   }
+   ```
+
+   `integration_id: 15368` is the GitHub Actions app — without it, GitHub treats the check name as ambiguous (any app could post it).
+
+3. Re-run `scripts/apply-rulesets.sh`.
+
+If you ever rename a workflow's `job` key or its `name:`, the check context name changes and any required check pinned to the old name will block all merges until you update the ruleset.
+
+## Editing tips
+
+- Don't hand-edit in the GitHub UI — your change will be silently overwritten the next time someone runs the apply script. Edit the JSON, commit, re-apply.
+- The `enforcement` field can be `"active"` (enforced) or `"evaluate"` (logged but not enforced — useful for testing a new rule).
+- The `conditions.ref_name.include` field supports `refs/heads/foo`, `refs/heads/foo/*`, and the special `~DEFAULT_BRANCH` / `~ALL` tokens.

--- a/.github/rulesets/develop.json
+++ b/.github/rulesets/develop.json
@@ -1,0 +1,33 @@
+{
+  "name": "develop-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/develop"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    }
+  ]
+}

--- a/.github/rulesets/hotfix.json
+++ b/.github/rulesets/hotfix.json
@@ -1,0 +1,22 @@
+{
+  "name": "hotfix-branches-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/hotfix/*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" }
+  ]
+}

--- a/.github/rulesets/main.json
+++ b/.github/rulesets/main.json
@@ -1,0 +1,33 @@
+{
+  "name": "main-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    }
+  ]
+}

--- a/.github/rulesets/release.json
+++ b/.github/rulesets/release.json
@@ -1,0 +1,33 @@
+{
+  "name": "release-branches-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ],
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/release/*"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    }
+  ]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,3 +92,170 @@ cd android && ./gradlew test                  # Unit tests
 - `prd.json` — User stories with `passes: true/false` status (Ralph loop format)
 - `progress.txt` — Append-only log with story status and iteration details
 - PRD: `Daily OK-PRD-v1.md` — Full product requirements document
+
+---
+
+## Critical Rules
+
+These rules override default behavior. Claude MUST follow them.
+
+### 1. Branch first, code second
+
+**Before writing or pushing code on any non-trivial task, Claude must confirm the target branch with the user.** A "non-trivial task" is anything that edits committed code, migrations, workflows, or app config — i.e. anything that would end up in a commit. Pure read/research is exempt.
+
+The check is one short question to the user before the first Edit/Write/commit. Map common request phrasings to branches as follows:
+
+| If the user says something like…                                                | Branch from | Target branch          |
+| ------------------------------------------------------------------------------- | ----------- | ---------------------- |
+| "production bug", "users are broken right now", "hotfix", "critical", "P0"      | `main`      | `hotfix/<short-desc>`  |
+| "new feature", "add X", "let's build…", "experiment", "WIP", "POC"              | `develop`   | `feat/<short-desc>` or `claude/<short-desc>-XXXX` |
+| "fix bug" (not customer-down), "refactor", "cleanup", "docs", "test"            | `develop`   | `feat/<short-desc>` or `claude/<short-desc>-XXXX` |
+| "release prep", "cut a release", "version bump", "App Store / Play submission"  | `develop`   | `release/<x.y.z>`      |
+| "rebase release branch", "merge develop into release"                           | n/a         | existing `release/*`   |
+
+If the request is ambiguous between hotfix and feature (e.g. "fix the wonky onboarding copy"), default to **feature off `develop`** and ask. Never start work directly on `main`, `develop`, or an unrelated `release/*`/`hotfix/*` branch.
+
+### 2. Never push to protected branches
+
+Never push directly to `main`, `develop`, `release/*`, or `hotfix/*` (the branch itself is protected against force-push and deletion; hotfix branches do allow direct commits while the hotfix is being built, but the merge to `main` must be a PR). Always open a PR.
+
+### 3. Database & API migrations are forward-only across releases
+
+See "Backward Compatibility" below. Any destructive change must be split into at least two releases.
+
+---
+
+## Branching & Release
+
+The branching model is a slimmed-down Git Flow adapted to Daily OK's surfaces (iOS App Store, Google Play, edge functions on Coolify, website on Cloudflare Pages, self-hosted Supabase).
+
+### Branch map
+
+| Branch / pattern                | Branches from           | Merges into             | Deploys to                                                                                                       | Purpose                                                                 |
+| ------------------------------- | ----------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `main`                          | —                       | —                       | **Production**: App Store / Play Store builds, edge functions Docker image to ghcr.io, Supabase migrations against prod, Cloudflare Pages prod site | Merge-only. Every merge is a release candidate. Tagged on release.      |
+| `develop`                       | `main` (initial)        | `release/*`, `hotfix/*` back-merge | **Staging** *(not wired up yet — see follow-ups)*: TestFlight internal, Play internal track, staging edge functions, staging Supabase, CF Pages preview | Long-lived integration branch. Where feature PRs land.                  |
+| `feat/<short-desc>` or `claude/<short-desc>-XXXX` | `develop`               | `develop`               | Per-branch CF Pages preview only. No mobile builds, no migrations run.                                            | Single feature or fix. Squash-merge into `develop`.                     |
+| `release/<x.y.z>`               | `develop`               | `main` (then back-merge to `develop`) | Release candidate builds: TestFlight external, Play closed/open testing, staging edge functions for final smoke   | Stabilization branch for a specific version. Only bug fixes + version bumps; no new features. |
+| `hotfix/<short-desc>`           | `main`                  | `main` (then back-merge to `develop` and any open `release/*`) | Production after merge. Same deploy targets as `main`.                                                            | Emergency prod fix that skips queued features on `develop`.             |
+
+### Release flow
+
+1. **Feature work** → branch off `develop` as `feat/foo` or `claude/foo-abcd`. PR back into `develop`. CI runs build + tests on the PR. Squash-merge.
+2. **Cut a release** → branch `release/x.y.z` off `develop`. Bump versions (iOS `MARKETING_VERSION`, Android `versionName`/`versionCode`, edge functions if you tag them). Submit iOS to App Store Connect, Android to Play Console. Fix any review feedback only on `release/x.y.z` (cherry-pick to `develop` or back-merge).
+3. **Release ships** → PR `release/x.y.z` → `main`. After merge, tag `vx.y.z` on `main`. Back-merge `main` → `develop` so any release-only fixes return to integration.
+4. **Hotfix** → branch `hotfix/foo` off `main`. Commit fixes directly on the hotfix branch (allowed by ruleset). PR `hotfix/foo` → `main`. After merge, tag, then back-merge `main` → `develop` AND `main` → any open `release/*`.
+
+### Rules of thumb
+
+- **Hotfixes always branch from `main`, never from `develop`.** `develop` may contain unreleased features that aren't ready to ship.
+- **Web-only changes during mobile review** — ship them via a normal `feat/* → develop → release/web-only → main` flow (or just `feat/* → develop`, then a release PR `develop → main` that only touches `website/` paths). The mobile workflows are path-filtered to `ios/**` and `android/**`, so they won't fire.
+- **Edge-function-only changes** — same: `feat/* → develop`, then `develop → main` via PR; the edge-functions workflow is path-filtered to `edge-functions/**`.
+- **Supabase migrations** — see "Backward Compatibility" below. Migrations land on `develop`, then ride to `main` in a release. **Migrations that are not backward-compatible with the currently-shipped mobile builds must wait** until `MIN_SUPPORTED_*_VERSION` catches up.
+- **Never force-push** `main`, `develop`, `release/*`, or `hotfix/*` (ruleset enforces this).
+- **Never merge `develop` → `main` directly outside a `release/*` or `hotfix/*` PR.** Always go through a release branch so there's a stabilization window.
+- **Never delete** `main`, `develop`, `release/*`, or `hotfix/*` (ruleset enforces this). Delete `feat/*` / `claude/*` after merge as normal.
+- **Don't pile features into `release/*`.** If new work is needed, it goes to `develop`; `release/*` only takes bug fixes and version bumps for that release.
+
+### Versioning
+
+- Tag releases on `main` as `v<major>.<minor>.<patch>`.
+- iOS marketing version + Android `versionName` should match the tag. Build numbers (`CFBundleVersion`, `versionCode`) are monotonically increasing per platform regardless of marketing version.
+- Edge functions: optional `edge-vYYYY.MM.DD.N` tag for traceability; Docker images on ghcr.io are tagged with the commit SHA already.
+
+---
+
+## Backward Compatibility (load-bearing surfaces)
+
+Daily OK has live users with installed iOS and Android apps that may lag the latest store version by weeks or months. **Any client an active user still runs is a constraint on the backend.** Define and respect:
+
+```
+MIN_SUPPORTED_IOS_APP_VERSION       // bump only when force-update is shipped
+MIN_SUPPORTED_ANDROID_APP_VERSION   // bump only when force-update is shipped
+```
+
+(Currently these are not defined as constants. Follow-up: add to `edge-functions/shared/config.ts` and have the auth/checkin endpoints reject older builds with a force-update payload. Until that exists, treat the *oldest store-approved build* as the floor.)
+
+The multi-release deprecation flow applies to **every** persistent shape below:
+
+> **Add new shape → dual-write/dual-read → migrate readers off old shape → wait ≥1 store release at the new `MIN_SUPPORTED_*_VERSION` → retire old shape**
+
+### A) Supabase / PostgreSQL
+
+**Always safe (single release):**
+- `CREATE TABLE` (new table)
+- `ADD COLUMN ... NULL` with a safe default (no `NOT NULL` on existing data yet)
+- `CREATE INDEX CONCURRENTLY` (use `CONCURRENTLY` to avoid locks)
+- New RLS policies that are additive (more permissive paths), not replacements
+- New `RPC` (Postgres function) — never modify an existing one's signature
+- New pg_cron job
+- New enum value **at the end** of the enum (`ALTER TYPE ... ADD VALUE 'foo'`)
+
+**Never do in a single release:**
+- `DROP COLUMN` — first stop writing it, then stop reading it, ship that, *then* drop in a later release
+- `DROP TABLE`
+- `RENAME COLUMN` / `RENAME TABLE` — clients reference these by name; split into add-new + dual-write + migrate-readers + drop-old across 2+ releases
+- Adding `NOT NULL` or tightening `CHECK` constraints on existing columns — backfill first in release N, enforce in release N+1
+- Changing a column's type (`ALTER COLUMN ... TYPE ...`) when the on-the-wire JSON shape changes
+- Removing or renaming enum values (`ALTER TYPE ... RENAME VALUE` / dropping a value via re-creation) — clients may still send them
+- Reducing the parameter list of an existing RPC, or removing an RPC entirely — apps in the wild still call it
+- Tightening RLS so previously-allowed reads/writes now fail
+- Deleting a pg_cron job that an in-flight client expects to have run
+- Tightening foreign keys (`ON DELETE` behavior change) without verifying existing data
+
+**Migration discipline:**
+- Each file in `supabase/migrations/` is numbered sequentially and wrapped in `BEGIN; ... COMMIT;`.
+- Migrations only run from `main` (via `supabase-migrations.yml` workflow + production environment approval + pre-migration backup).
+- A migration that is destructive against currently-shipped clients must not merge to `main` until the prerequisite client release is at or below `MIN_SUPPORTED_*_VERSION`.
+
+### B) Edge function HTTP API
+
+The edge functions are a public API consumed by installed iOS and Android apps. Treat the request/response JSON shapes as a versionless public contract.
+
+**Always safe:**
+- New endpoints
+- New **optional** request fields (server tolerates missing)
+- New response fields (clients ignore unknown keys — verify the iOS/Android decoders do this; Swift `Decodable` ignores extras by default; Kotlin/Moshi requires `@JsonClass(generateAdapter = true)` with non-strict)
+- Looser auth requirements (e.g. allow anonymous on an endpoint that previously required auth) — only if intentional
+- Adding response fields with a safe default
+
+**Never do in a single release:**
+- Remove or rename an endpoint
+- Remove or rename a request/response field
+- Tighten a required request field (e.g. make optional → required, or narrow accepted enum values)
+- Change a field's type (`string` → `number`, `array` → `object`)
+- Change the meaning of an HTTP status code (e.g. previously `200 {ok: false}`, now `400`)
+- Tighten rate limits below what an in-flight client may legitimately hit on its retry schedule
+
+**Versioning approach:** prefer additive evolution over a new path. If you must do a breaking change, add a new endpoint (`/v2/foo`), dual-serve both, migrate clients over `MIN_SUPPORTED_*_VERSION` cycles, then retire `/v1/foo`.
+
+### C) Mobile app on-device state
+
+iOS and Android both persist data on-device (Keychain / EncryptedSharedPreferences, Room DB on Android, UserDefaults on iOS). When the user upgrades, the *new* app reads the *old* app's data.
+
+**Always safe:**
+- Adding new keys / new Room columns with `defaultValue` and `@ColumnInfo(defaultValue=…)` / Room auto-migrations
+- Adding new optional fields to encoded structs (Codable / Moshi)
+
+**Never do in a single release:**
+- Renaming a Room table/column without a migration that copies data
+- Renaming a `UserDefaults` / `EncryptedSharedPreferences` key without a one-time read-old-write-new shim on first launch
+- Changing the `Codable`/Moshi shape of a value that's already serialized to disk
+- Bumping Room `version` without a migration (Room will throw at runtime)
+
+### D) Push notification token / platform contract
+
+`push_tokens.platform` is `'ios' | 'android'`. Never reuse those values or change their meaning. New platforms (e.g. `'web'`) are additive.
+
+### E) Subscription state (StoreKit 2 / Google Play Billing)
+
+- Never delete or rename product IDs in App Store Connect / Play Console; create new ones and migrate.
+- The mapping from store product ID → tier is checked in `supabase/migrations` and edge function code; keep all historical product IDs recognized as long as any subscriber may still hold one.
+
+### Authoring checklist for a PR that touches persistent state
+
+- [ ] If it touches `supabase/migrations/**`, is the change in the "always safe" list, or is it split across releases?
+- [ ] If it touches `edge-functions/**` JSON shapes, does the oldest still-supported mobile build still parse the response and produce a valid request?
+- [ ] If it touches mobile on-device persistence (Room, UserDefaults, Keychain keys), is there a migration / shim for users upgrading from the previous build?
+- [ ] If it removes anything, has the deprecation flow run for at least one full release cycle?
+- [ ] PR description names which release this is targeted at and which `MIN_SUPPORTED_*_VERSION` it assumes.

--- a/scripts/apply-rulesets.sh
+++ b/scripts/apply-rulesets.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Apply (or re-apply) the branch protection rulesets defined in
+# .github/rulesets/*.json against the GitHub repo.
+#
+# Idempotent: for each JSON file, look up an existing ruleset by name. If found,
+# PUT to update it; if not, POST to create it.
+#
+# Requirements:
+#   - gh CLI authenticated (`gh auth status`) with `repo` + `administration` scopes,
+#     OR a GITHUB_TOKEN env var with the same scopes.
+#   - jq
+#
+# Usage:
+#   bash scripts/apply-rulesets.sh
+#
+# Optional env vars:
+#   OWNER  (default: dj-pearson)
+#   REPO   (default: wellvo)
+#   DRY_RUN=1 to print intended actions without calling the API.
+
+set -euo pipefail
+
+OWNER="${OWNER:-dj-pearson}"
+REPO="${REPO:-wellvo}"
+RULESETS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.github/rulesets"
+DRY_RUN="${DRY_RUN:-0}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq is required" >&2
+  exit 1
+fi
+
+# Pick an API caller: prefer gh, fall back to curl with GITHUB_TOKEN.
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  api() {
+    local method="$1" path="$2"
+    if [[ "${3:-}" == "--input" ]]; then
+      gh api -X "$method" "$path" --input "$4"
+    else
+      gh api -X "$method" "$path"
+    fi
+  }
+  echo "using: gh CLI"
+elif [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  api() {
+    local method="$1" path="$2"
+    local url="https://api.github.com/${path#/}"
+    if [[ "${3:-}" == "--input" ]]; then
+      curl -fsSL -X "$method" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        -H "Content-Type: application/json" \
+        --data-binary "@$4" \
+        "$url"
+    else
+      curl -fsSL -X "$method" \
+        -H "Authorization: Bearer $GITHUB_TOKEN" \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "$url"
+    fi
+  }
+  echo "using: curl + GITHUB_TOKEN"
+else
+  echo "error: need either 'gh' authenticated or GITHUB_TOKEN env var" >&2
+  exit 1
+fi
+
+echo "==> Listing existing rulesets on $OWNER/$REPO"
+existing="$(api GET "repos/$OWNER/$REPO/rulesets")"
+
+declare -A name_to_id=()
+while IFS=$'\t' read -r id name; do
+  [[ -z "$name" ]] && continue
+  name_to_id["$name"]="$id"
+done < <(echo "$existing" | jq -r '.[] | [.id, .name] | @tsv')
+
+echo "    found ${#name_to_id[@]} existing ruleset(s)"
+
+shopt -s nullglob
+for f in "$RULESETS_DIR"/*.json; do
+  name="$(jq -r '.name' "$f")"
+  if [[ -z "$name" || "$name" == "null" ]]; then
+    echo "    skip $f (no .name field)" >&2
+    continue
+  fi
+
+  if [[ -n "${name_to_id[$name]:-}" ]]; then
+    id="${name_to_id[$name]}"
+    echo "==> UPDATE  $name  (id=$id)  <- $f"
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "    (dry-run) PUT repos/$OWNER/$REPO/rulesets/$id"
+    else
+      api PUT "repos/$OWNER/$REPO/rulesets/$id" --input "$f" >/dev/null
+    fi
+  else
+    echo "==> CREATE  $name              <- $f"
+    if [[ "$DRY_RUN" == "1" ]]; then
+      echo "    (dry-run) POST repos/$OWNER/$REPO/rulesets"
+    else
+      api POST "repos/$OWNER/$REPO/rulesets" --input "$f" >/dev/null
+    fi
+  fi
+done
+
+echo
+echo "==> Done. Verify in GitHub UI: https://github.com/$OWNER/$REPO/rules"
+
+# ---------------------------------------------------------------------------
+# Bootstrap: ensure 'develop' branch exists before the develop ruleset has
+# anything to protect. Safe to run repeatedly.
+# ---------------------------------------------------------------------------
+echo
+echo "==> Ensuring 'develop' branch exists"
+if api GET "repos/$OWNER/$REPO/branches/develop" >/dev/null 2>&1; then
+  echo "    develop already exists"
+else
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "    (dry-run) would create develop from main"
+  else
+    main_sha="$(api GET "repos/$OWNER/$REPO/git/ref/heads/main" | jq -r '.object.sha')"
+    echo "    creating develop from main@$main_sha"
+    tmp="$(mktemp)"
+    jq -n --arg sha "$main_sha" '{ref: "refs/heads/develop", sha: $sha}' > "$tmp"
+    api POST "repos/$OWNER/$REPO/git/refs" --input "$tmp" >/dev/null
+    rm -f "$tmp"
+    echo "    develop created"
+  fi
+fi


### PR DESCRIPTION
## Summary

This PR documents and enforces the branching model, release workflow, and backward compatibility constraints for Daily OK. It adds:

1. **Critical rules** in `CLAUDE.md` that override default behavior for branch selection and code safety
2. **Git Flow variant** with `main`, `develop`, `release/*`, `hotfix/*`, and feature branches
3. **Backward compatibility framework** for Supabase migrations, edge function APIs, mobile on-device state, and subscription contracts
4. **GitHub branch protection rulesets** as version-controlled JSON files with an idempotent apply script

## Key Changes

- **CLAUDE.md**: Added ~170 lines documenting:
  - Rule 1: Confirm target branch before writing code (hotfix vs. feature vs. release)
  - Rule 2: Never push directly to protected branches; always use PRs
  - Rule 3: Database & API migrations are forward-only across releases
  - Full branching model with branch map, release flow, and rules of thumb
  - Versioning scheme (`v<major>.<minor>.<patch>`)
  - Multi-release deprecation flow for persistent shapes (DB, API, mobile state, subscriptions)
  - Authoring checklist for PRs touching persistent state

- **scripts/apply-rulesets.sh**: New bash script to idempotently apply branch protection rulesets:
  - Detects `gh` CLI or `GITHUB_TOKEN` for authentication
  - Lists existing rulesets and matches by name
  - Creates new rulesets or updates existing ones
  - Bootstraps the `develop` branch if it doesn't exist
  - Supports dry-run mode

- **.github/rulesets/README.md**: Documentation for the ruleset system:
  - Explains why rulesets over classic branch protection
  - Maps branches to their protections
  - Describes bypass actors and approval requirements
  - Instructions for applying and editing rulesets
  - Guidance on adding required status checks

- **.github/rulesets/*.json**: Four branch protection rulesets:
  - `main.json`: Blocks deletion & force-push, requires PR (0 approvals), dismisses stale reviews on push
  - `develop.json`: Blocks deletion & force-push, requires PR (0 approvals)
  - `release.json`: Blocks deletion & force-push, requires PR (0 approvals)
  - `hotfix.json`: Blocks deletion & force-push only (direct commits allowed on the branch; PR gate is at `hotfix/* → main`)

## Notable Details

- **Approval count is 0** because GitHub doesn't allow PR authors to self-approve; this is intentional for solo-developer setup and should be bumped to 1 when a second reviewer joins
- **Hotfix branches allow direct commits** to enable rapid fixes, but the merge to `main` is still gated by the `main-protection` ruleset
- **Rulesets are idempotent**: re-running the apply script converges the remote state to match the JSON files
- **Backward compatibility is multi-release**: destructive changes (column drops, endpoint removals, etc.) must be split across at least two releases with a deprecation window
- **Supabase migrations** are the load-bearing constraint; they can only run against currently-shipped mobile builds, enforced by `MIN_SUPPORTED_*_VERSION` constants (to be added in a follow-up)

https://claude.ai/code/session_01P8qYZxGiwJhfMhmnV5Z2KG