### PR TITLE
docs: add iOS App Store ranking / ASO strategy

### DIFF
--- a/.github/workflows/ios-e2e-tests.yml
+++ b/.github/workflows/ios-e2e-tests.yml
@@ -171,6 +171,26 @@ jobs:
           path: ${{ runner.temp }}/TestResults.xcresult
           retention-days: 7
 
+      - name: Run Unit Tests
+        working-directory: ios
+        run: |
+          set -o pipefail
+          xcodebuild test-without-building \
+            -project DailyOK.xcodeproj \
+            -scheme DailyOK \
+            -destination "id=${{ env.DEVICE_ID }}" \
+            -only-testing:DailyOKTests \
+            -resultBundlePath $RUNNER_TEMP/UnitTestResults.xcresult \
+            | xcbeautify
+
+      - name: Upload unit test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-results
+          path: ${{ runner.temp }}/UnitTestResults.xcresult
+          retention-days: 7
+
       - name: Shutdown simulator
         if: always()
         run: xcrun simctl shutdown "${{ env.DEVICE_ID }}" 2>/dev/null || true

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,63 @@
+name: Generate App Store Screenshots
+
+# Renders the App Store screenshot sets from the HTML mockups in `screenshots/`.
+# Produces two downloadable artifacts so they can be compared / rolled back:
+#   - app-store-screenshots-v1  → bare app screens (original)
+#   - app-store-screenshots-v2  → marketing frames with caption headlines (new)
+# Download the artifact from the workflow run and upload the chosen set to
+# App Store Connect. See docs/ASO_STRATEGY.md §5.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, develop]
+    paths:
+      - 'screenshots/src/**'
+      - 'screenshots/package.json'
+      - '.github/workflows/screenshots.yml'
+  pull_request:
+    paths:
+      - 'screenshots/src/**'
+      - 'screenshots/package.json'
+      - '.github/workflows/screenshots.yml'
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: screenshots
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Render v1 (bare app screens)
+        run: npm run capture
+
+      - name: Render v2 (caption marketing frames)
+        run: npm run capture:v2
+
+      - name: Upload v1 screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-store-screenshots-v1
+          path: screenshots/output/
+          if-no-files-found: error
+
+      - name: Upload v2 screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-store-screenshots-v2
+          path: screenshots/output-v2/
+          if-no-files-found: error

--- a/docs/APP_STORE_CONNECT_AND_SUPABASE_SETUP.md
+++ b/docs/APP_STORE_CONNECT_AND_SUPABASE_SETUP.md
@@ -20,12 +20,33 @@
 
 ## 1. Apple App Store Connect — Full Metadata
 
+### 1.0 Metadata Version History (rollback reference)
+
+We optimize the listing for App Store ranking in **versions** so every change is
+reversible. **v2** is the current ASO-optimized set (rationale and full plan in
+`docs/ASO_STRATEGY.md`). If a version underperforms, paste the previous column
+back into the fields below and submit a metadata-only update (reusing the build).
+
+| Field | v1 (original — 2026-03 launch) | v2 (current — ASO-optimized, 2026-06) |
+| --- | --- | --- |
+| App Name | `Daily OK — Daily Check-In` | `Daily OK: Senior Check-In` |
+| Subtitle | `One tap. Peace of mind.` | `Elderly safety & care alerts` |
+| Keywords (en-US) | `check in,family safety,aging parents,daily check,senior safety,teen check in,caregiver,peace of mind` | `aging,parent,family,caregiver,reminder,alone,fall,wellbeing,mood,emergency,sos,loved,safe,wellness` |
+| Keywords (en-GB) | _(localization did not exist)_ | `checkup,welfare,distress,dementia,independent,living,vulnerable,relative,grandparent,reassurance` |
+| Keywords (en-AU) | _(localization did not exist)_ | `carer,housebound,frail,disabled,recovery,anxiety,worry,neighbour,support,connection,checkin,nudge` |
+| Promotional Text | `The #1 daily check-in app for families. Know your aging parent or teenager is OK with one tap. No tracking. No surveillance. Just peace of mind.` | `Set up a daily check-in for someone you love in under 2 minutes. Get an alert the moment they miss one. No tracking — just peace of mind.` |
+| Screenshots | bare app screens — `screenshots/output/` | caption-headline marketing frames — `screenshots/output-v2/` (run `npm run capture:v2`) |
+
+> **Reverting screenshots:** the v1 (bare) PNGs are preserved untouched in
+> `screenshots/output/`; the v2 captioned set generates into `screenshots/output-v2/`.
+> Switch the App Store Connect upload between the two folders to roll forward/back.
+
 ### 1.1 App Information
 
 | Field                  | Value                                |
 | ---------------------- | ------------------------------------ |
-| **App Name**           | Daily OK — Daily Check-In              |
-| **Subtitle**           | One tap. Peace of mind.              |
+| **App Name**           | Daily OK: Senior Check-In _(v2 — see §1.0)_ |
+| **Subtitle**           | Elderly safety & care alerts _(v2 — see §1.0)_ |
 | **Bundle ID**          | `net.dailyok.app`                     |
 | **SKU**                | `dailyok-ios-001`                     |
 | **Primary Language**   | English (U.S.)                       |
@@ -96,17 +117,45 @@ Privacy Policy: https://dailyok.net/privacy
 Terms of Use: https://dailyok.net/terms
 ```
 
-#### Promotional Text (170 chars, can be updated without new build)
+#### Promotional Text (170 chars, can be updated without new build) — v2
 
 ```
-The #1 daily check-in app for families. Know your aging parent or teenager is OK with one tap. No tracking. No surveillance. Just peace of mind.
+Set up a daily check-in for someone you love in under 2 minutes. Get an alert the moment they miss one. No tracking — just peace of mind.
 ```
 
-#### Keywords (100 characters max)
+> v1 (rollback): `The #1 daily check-in app for families. Know your aging parent or teenager is OK with one tap. No tracking. No surveillance. Just peace of mind.`
+> v2 drops the unverifiable "#1" superlative (App Review rejection risk) for a benefit-led CTA. Promotional Text is **not** indexed for search — it only affects conversion — and can be edited anytime without a new version.
+
+#### Keywords (100 characters max) — v2
+
+**English (U.S.)** — 98/100:
 
 ```
-check in,family safety,aging parents,daily check,senior safety,teen check in,caregiver,peace of mind
+aging,parent,family,caregiver,reminder,alone,fall,wellbeing,mood,emergency,sos,loved,safe,wellness
 ```
+
+Add two more English localizations to the same version (reuse U.S. screenshots/
+description). Apple indexes en-GB and en-AU keyword fields for U.S.-storefront
+searches too — this ~triples indexed keyword coverage for ~30 min of work. Treat
+as a measured experiment (track keyword impressions for 2 weeks). See
+`docs/ASO_STRATEGY.md §4`.
+
+**English (U.K.)** — 96/100:
+
+```
+checkup,welfare,distress,dementia,independent,living,vulnerable,relative,grandparent,reassurance
+```
+
+**English (Australia)** — 97/100:
+
+```
+carer,housebound,frail,disabled,recovery,anxiety,worry,neighbour,support,connection,checkin,nudge
+```
+
+> v1 (rollback en-US): `check in,family safety,aging parents,daily check,senior safety,teen check in,caregiver,peace of mind`
+> Rules applied in v2: single tokens (Apple recombines them into phrases), no
+> word repeated across Name/Subtitle/Keywords, singular forms, commas with no
+> spaces, and no competitor trademarks (we conquest those via Search Ads instead).
 
 #### What's New (v1.0.0)
 

--- a/docs/ASO_STRATEGY.md
+++ b/docs/ASO_STRATEGY.md
@@ -1,0 +1,219 @@
+# Daily OK — iOS App Store Ranking & ASO Strategy
+
+**Owner:** Pearson Media LLC
+**Status:** Proposed (pending approval of repositioning decision in §2)
+**Last updated:** 2026-06-12
+**Goal:** Increase App Store **impressions** and organic installs by ranking for more of the searches our buyers actually type, and by converting more of the impressions we already get.
+
+> This plan **supersedes** the metadata values in `docs/APP_STORE_CONNECT_AND_SUPABASE_SETUP.md §1.3` once approved. None of it changes the app binary except the in-app review prompt (§6) and optional Custom Product Page deep links (§5), which ride the normal `develop → release` flow. Everything else is App Store Connect configuration.
+
+---
+
+## 1. Why impressions are low today (diagnosis)
+
+App Store impressions come from three surfaces: **Search** (~65% of installs industry-wide), **Browse** (category/Today/charts), and **Referral** (web/ads). We are starving all three:
+
+| Problem | Evidence (current listing) | Cost |
+| --- | --- | --- |
+| **Name wastes its strongest ranking field** | `Daily OK — Daily Check-In` repeats "Daily" twice and spends the most heavily-weighted field on no high-intent category words (senior, elderly, safety). | We don't rank for the terms buyers search. |
+| **Subtitle is brand fluff, not keywords** | `One tap. Peace of mind.` — the #2 ranking field spent on near-zero-volume words ("one", "tap", "peace", "mind"). | ~23 wasted keyword-weighted chars. |
+| **Keyword field duplicates name/subtitle & uses phrases** | `...daily check...` (dup of name), `...peace of mind` (dup of subtitle), and multi-word phrases ("family safety", "senior safety", "teen check in") burn characters Apple would otherwise let us spend on *more tokens*. Apple auto-combines single tokens across fields. | ~30 of 100 chars wasted; missing tokens like elderly, alone, fall, reminder, caregiver, wellbeing, SOS. |
+| **Only one keyword field exists** | App is **English (U.S.) only**, **US storefront only**. | Leaving ~200 extra indexable keyword characters on the table (see §4). |
+| **Screenshots have no caption headlines** | `screenshots/src/screens.ts` renders bare device UI — no value-prop text above the frame. The first 2–3 screenshots show in search results *without a tap*. | Low tap-through → low install conversion → Apple suppresses rank → fewer impressions. Downward flywheel. |
+| **No paid amplification** | No Apple Search Ads. | No way to bootstrap the download velocity that lifts organic rank in a competitive niche. |
+| **Thin ratings volume** | No in-app `SKStoreReviewController` prompt. | Rating count + average is both a ranking signal and the single biggest CVR lever; Snug Safety has thousands. |
+
+**The flywheel we're fighting:** rank is driven by *relevance* (keywords) **×** *conversion* (tap-through + install rate) **×** *velocity* (recent downloads) **×** *retention/ratings*. Low CVR and low velocity cap our rank even on terms we're relevant for, which caps impressions, which caps velocity. We break the loop by fixing relevance + CVR + buying initial velocity simultaneously.
+
+---
+
+## 2. Strategic decision: who we optimize the *metadata* for
+
+The product serves seniors, teens, and any loved one. **ASO metadata can't be all things to all people** — it must capture the largest, highest-intent search demand. That is unambiguously the **aging-parent / senior-safety** segment (the same audience our pSEO and `website/src/data/competitors/*` already target, and the 53M-caregiver demographic in our review notes).
+
+- **Recommended:** lead the **name + subtitle** with senior/elderly/safety language. Keep teens/couples/long-distance in the **description body** and dedicated **Custom Product Pages** (§5), so we lose no positioning — we just stop diluting the highest-weight fields.
+- **Alternative (if leadership wants to stay broad):** use the broad name variant in §3 and accept lower search relevance per term.
+
+Everything below assumes the recommended path. **This is the one call that needs sign-off before we ship metadata.**
+
+---
+
+## 3. New metadata (ready to paste) — *fixes Search relevance*
+
+All strings below are **character-counted against Apple's hard limits**. Tokens are never repeated across fields (Apple indexes the union of Name + Subtitle + Keywords + IAP display names), use **singular** forms (Apple matches plurals), and the keyword field uses **commas with no spaces** (every space is a wasted character).
+
+### App Name — 25/30
+```
+Daily OK: Senior Check-In
+```
+*Broad alternative (25/30):* `Daily OK: Family Check-In`
+Adds tokens: **senior, check, in** (or family). Keeps the "Daily OK" brand first.
+
+### Subtitle — 28/30
+```
+Elderly safety & care alerts
+```
+Adds tokens: **elderly, safety, care, alerts** — all high-intent, none duplicated in the name.
+
+### Keywords (English U.S.) — 98/100
+```
+aging,parent,family,caregiver,reminder,alone,fall,wellbeing,mood,emergency,sos,loved,safe,wellness
+```
+Rules applied: no word already in Name/Subtitle, single tokens (Apple builds the phrases, e.g. *senior* × *safe* × *aging* × *parent* → "senior safety", "safe aging parent"), no `app`, no category names, **no competitor trademarks** (Snug/Life360/Papa as keywords risk rejection — we bid on those in Search Ads instead, see §7).
+
+**Net effect:** the indexed token set jumps from ~12 phrase-fragments to ~25+ single tokens that recombine into hundreds of long-tail phrases ("check in app for aging parent", "elderly fall alert", "senior wellness reminder", "safety app for mom alone", etc.).
+
+### Promotional Text — editable anytime, **not** indexed (drives CVR, not rank)
+Replace the unverifiable `The #1 daily check-in app...` (an App-Review-risky superlative) with a benefit CTA:
+```
+Set up a daily check-in for someone you love in under 2 minutes. Get an alert the moment they miss one. No tracking — just peace of mind.
+```
+
+> **Submission note:** Name, Subtitle, Keywords, and Screenshots changes require a new **version** in review, but can **reuse the current build** (metadata-only update). Promotional Text updates need no review. Bundle §3 + §5 screenshots into one metadata-only version submission.
+
+---
+
+## 4. Localization keyword expansion — *the highest-ROI, lowest-effort lever for impressions*
+
+Apple indexes the keyword fields of **English (U.K.)** and **English (Australia)** for searches **in the U.S. storefront**, and **Spanish (Mexico)** Spanish keywords are indexed for U.S. searchers too. Today we have **one** English (U.S.) field. Adding two more English localizations (reusing the same screenshots/description, only the keyword field differs) roughly **triples our indexed keyword surface — ~98 → ~291 characters — with no new build and no new creative.**
+
+> Caveat (honesty): Apple has never formally documented the en-GB/en-AU cross-indexing and it has been narrowed over the years. It costs ~30 minutes to add and is fully reversible, so we treat it as a **measured experiment**, not a guarantee. Track impression lift in App Store Connect → Analytics by keyword over the 2 weeks after adding.
+
+### English (U.K.) keyword field — 96/100
+```
+checkup,welfare,distress,dementia,independent,living,vulnerable,relative,grandparent,reassurance
+```
+
+### English (Australia) keyword field — 97/100
+```
+carer,housebound,frail,disabled,recovery,anxiety,worry,neighbour,support,connection,checkin,nudge
+```
+
+### Phase 2 — Spanish (Mexico), once core is validated
+Add a Spanish keyword field (e.g. `cuidado,ancianos,mayores,abuela,abuelo,seguridad,recordatorio,bienestar,familia,emergencia,solo,salud`) and Spanish screenshots/description. Captures the large U.S. Hispanic-caregiver market that English metadata can't reach.
+
+**Action:** in App Store Connect, add the en-GB and en-AU localizations to the existing version, paste the keyword fields above, reuse U.S. screenshots/description (light British spelling on the en-GB description is a nice-to-have, not required).
+
+---
+
+## 5. Conversion-rate (CVR) overhaul — *turn the impressions we get into installs*
+
+Higher CVR both lifts installs **and** lifts rank (Apple rewards it), so this compounds with §3–4.
+
+### 5.1 Screenshots — add caption headlines (biggest CVR lever)
+Current screenshots are bare app UI. Top-ranking apps put a **bold 3–6 word headline above the device frame**. The first **2–3 portrait screenshots render in search results without a tap** — they must sell the value instantly. Extend `screenshots/src/screens.ts` to render a caption band (brand Calm Green `#2ECC71` / Deep Slate `#1E293B`, Inter Bold) above each device.
+
+Recommended sequence (screen → headline):
+1. `receiver-checkin` → **"Know they're OK — every single day"**
+2. `receiver-done` → **"One tap. They're safe."**
+3. *(escalation/alert mock)* → **"Get alerted the moment they miss a check-in"**
+4. `owner-dashboard` → **"See everyone you care about at a glance"**
+5. *(trust frame)* → **"No tracking. No cameras. No surveillance."**
+6. `history-heatmap` → **"Spot worrying patterns early"**
+7. `plan-selection`/onboarding → **"Set it up in under 2 minutes"**
+
+Add an **App Preview video** (15–30s) per the storyboard already in the setup guide §1.5.
+
+### 5.2 Product Page Optimization (PPO) — A/B test, don't guess
+Apple's built-in PPO lets us test up to **3 treatments** against the live page with statistically-measured install-rate. First tests:
+- **Test 1:** caption-overlay screenshots (§5.1) vs. current bare screenshots. *(Expected winner: captions, often +15–35% CVR.)*
+- **Test 2:** icon — current heart+check on green vs. a warmth variant (e.g., subtle two-person/family motif). Icon is the most-seen creative in search results.
+
+### 5.3 Custom Product Pages (CPP) — one page per audience/traffic source
+Build up to 35 CPPs, each with its own screenshots/captions, and point each traffic source at the matching page:
+- **CPP-Senior** ("aging parents living alone") → target for Apple Search Ads senior/elderly ad groups + senior-care pSEO pages.
+- **CPP-Teen** ("a respectful check-in for your teen") → teen/kid-mode ad groups + relevant blog posts.
+- **CPP-Couples** ("long-distance peace of mind") → couples/long-distance campaigns.
+Each CPP CVR is reported separately, and CPP traffic still feeds organic rank.
+
+### 5.4 Category test
+Primary is currently **Lifestyle** (huge, generic browse competition). Test **Health & Fitness** as primary — its browse/Today audience is far more intent-aligned with "check-in for a vulnerable parent" (Medical is not an available category). Reassess chart competitiveness after 2 weeks.
+
+---
+
+## 6. Ratings & reviews engine — *ranking + CVR compounding*
+
+Rating **count** and **average** drive both rank and install rate. We currently prompt for neither.
+
+- **Implement `SKStoreReviewController`** (StoreKit) at a genuinely positive moment, e.g. when the Owner first sees a **7-day streak**, or after a Receiver's **5th successful check-in**. Apple caps prompts at **3/year per user** — spend them on high-satisfaction moments only. *(This is the one app-code change; it ships via `feat/* → develop → release`.)*
+- **Seed the first 50+ ratings fast:** TestFlight users, the email list, and personal network — count/recency matter most in the first weeks.
+- **Respond to every review** in App Store Connect; responsiveness lifts CVR and shows Apple an actively-maintained listing.
+- **In-App Events:** publish a seasonal event (e.g. *"Holiday peace of mind"*, *"Caregiver setup week"*) — events get their own search/browse card and extra surface area.
+
+---
+
+## 7. Apple Search Ads — *buy the velocity that bootstraps organic rank*
+
+ASA is the fastest impressions lever and directly feeds the download-velocity signal that lifts organic rank. Use **ASA Advanced** (keyword-level control). Suggested start: **$30–50/day** total, then reallocate to whatever hits target CPI/CPA.
+
+| Campaign | Match | Targets | Purpose |
+| --- | --- | --- | --- |
+| **Brand defense** | Exact | `daily ok`, `dailyok`, `daily ok app` | Cheap, ~highest CVR; stop competitors poaching our brand searches. |
+| **Competitor conquest** | Exact | `snug`, `snug safety`, `life360`, `papa`, `medical guardian`, `lively`, `assureokay`, `checkin bee` | We *can* bid on competitor terms even though we can't use them as keywords. Point at CPP-Senior. |
+| **Generic high-intent** | Exact | `senior check in app`, `check in app for elderly`, `daily check in`, `safety app for seniors`, `wellness check app`, `app to check on aging parents`, `fall alert app` | Core demand. |
+| **Discovery** | Search Match + Broad | (auto) | Harvest converting terms → feed them into the organic keyword field (§3) and promote winners to Exact. |
+
+**Operating loop:** weekly, pull the Search Terms report → promote converting queries to Exact, add them to the organic keyword fields, and **negative-match** spend-with-no-install terms. ASA both buys installs *and* tells us exactly which organic keywords to chase.
+
+---
+
+## 8. Competitive landscape (who we're ranking against)
+
+| Competitor | Shape | Our wedge |
+| --- | --- | --- |
+| **Snug Safety** | Free daily check-in, 20M+ check-ins, AARP/Forbes; paid dispatch $19.99/mo | We're **multi-receiver / family-managed** (one payer manages everyone; receivers never see billing), have **escalation chains + mood/pattern alerts**, and are far cheaper than dispatch tiers. |
+| **AssureOkay / CheckIn More / CheckinBee** | SMS/voice check-ins, no-smartphone-required, low price | We own the **native-app + push** experience with a one-tap UI designed for 13–95, plus dashboard/history. |
+| **Life360** | Location-tracking family app | We are explicitly **not surveillance** — no location/cameras. Different intent; we conquest their brand term but position as the privacy-respecting alternative. |
+| **Medical Guardian / Lively / Bay Alarm** | Hardware medical-alert devices, $$$ | We're **app-only, no hardware, no contract**, a fraction of the price — the "before you need a medical alert" product. |
+
+Differentiation themes to carry through captions, CPPs, and ad copy: **family-managed (not single-user), privacy-first (not tracking), escalation that actually alerts you, designed for every age, no hardware/contract.**
+
+---
+
+## 9. 30 / 60 / 90-day rollout
+
+**Days 0–30 — Relevance + CVR foundation (do these first, highest ROI):**
+- [ ] Get sign-off on the §2 repositioning decision.
+- [ ] Ship new Name / Subtitle / Keywords (§3) as a metadata-only version (reuse current build).
+- [ ] Add en-GB + en-AU keyword localizations (§4).
+- [ ] Build caption-overlay screenshots (§5.1) + App Preview video.
+- [ ] Update Promotional Text (§3) — live immediately, no review.
+- [ ] Stand up Apple Search Ads: Brand + Competitor + Generic + Discovery (§7).
+- [ ] Implement `SKStoreReviewController` prompt (§6) — into `develop`, ride next release.
+
+**Days 30–60 — Optimize what's live:**
+- [ ] Launch PPO Test 1 (captions vs. bare) and Test 2 (icon) (§5.2).
+- [ ] Build CPP-Senior / CPP-Teen / CPP-Couples and wire ASA ad groups to them (§5.3).
+- [ ] Weekly ASA search-terms harvest → promote winners into organic keywords.
+- [ ] Test Primary category = Health & Fitness (§5.4).
+- [ ] Push ratings drive to 50+ (seed + in-app prompt live).
+
+**Days 60–90 — Scale & expand:**
+- [ ] Roll out PPO winners to the default page.
+- [ ] Add Spanish (Mexico) localization + screenshots (§4 Phase 2).
+- [ ] Publish first In-App Event (§6).
+- [ ] Expand availability beyond the U.S. (currently US-only) to open more storefronts/keyword fields once metadata is proven.
+- [ ] Reallocate ASA budget to lowest-CPA campaigns; consider scaling spend.
+
+---
+
+## 10. KPIs to watch (App Store Connect → Analytics)
+
+| Metric | Where | Target trend |
+| --- | --- | --- |
+| **Impressions** (Search vs. Browse split) | Analytics → Acquisition | ↑ — primary goal |
+| **Product Page Views** | Analytics | ↑ |
+| **Conversion Rate** (impression→install) | Analytics + PPO | ↑ (PPO measures lift precisely) |
+| **Keyword rankings** | ASA reports / 3rd-party (AppFigures/SensorTower) | More terms in top 10 |
+| **Ratings count & average** | App Store Connect | 50+ then climbing; avg ≥ 4.5 |
+| **ASA CPI / CPA & TTR/CR** | Search Ads dashboard | CPA ≤ target; reallocate weekly |
+| **Organic vs. paid install mix** | Analytics | Organic share ↑ over time (proof the flywheel is turning) |
+
+---
+
+## 11. Compliance & process notes
+
+- **Backward compatibility (`CLAUDE.md`):** §3–5, §7–8 are App Store Connect configuration — **no binary, no API, no DB change**, so no migration concerns. The only on-device code is the §6 review prompt (additive, safe) and optional §5.3 CPP deep-link handling — both ship via `feat/* → develop → release/*`.
+- **No competitor trademarks in metadata** (Name/Subtitle/Keywords/Description). Conquest only via Apple Search Ads bids, which is permitted.
+- **Avoid superlatives** ("#1", "best") in indexed/marketing text — App Review rejection risk; our Promotional Text rewrite removes the existing one.
+- This document supersedes the metadata in `docs/APP_STORE_CONNECT_AND_SUPABASE_SETUP.md §1.3`; update that file once the §2 decision is approved so there's a single source of truth.

--- a/ios/DailyOK.xcodeproj/project.pbxproj
+++ b/ios/DailyOK.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		B1C00020 /* EdgeFunctionsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C00020; };
 		B1C0000B /* BiometricService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C0000B; };
 		B1C0000C /* CertificatePinningService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C0000C; };
+		B1C00021 /* ReviewPromptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C00021; };
 		/* Utilities */
 		B1D00004 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D00004; };
 		/* Views/Components */
@@ -127,6 +128,7 @@
 		F1C00020 /* EdgeFunctionsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdgeFunctionsClient.swift; sourceTree = "<group>"; };
 		F1C0000B /* BiometricService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BiometricService.swift; sourceTree = "<group>"; };
 		F1C0000C /* CertificatePinningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CertificatePinningService.swift; sourceTree = "<group>"; };
+		F1C00021 /* ReviewPromptService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPromptService.swift; sourceTree = "<group>"; };
 		/* Utilities */
 		F1D00001 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
 		F1D00002 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
@@ -303,6 +305,7 @@
 				F1C00004 /* FamilyService.swift */,
 				F1C0000A /* HeartbeatService.swift */,
 				F1C00009 /* LocationService.swift */,
+				F1C00021 /* ReviewPromptService.swift */,
 				F1C00005 /* OfflineCheckInService.swift */,
 				F1C00006 /* PushNotificationService.swift */,
 				F1C00007 /* SubscriptionService.swift */,
@@ -565,6 +568,7 @@
 				B1C00020 /* EdgeFunctionsClient.swift in Sources */,
 				B1C0000B /* BiometricService.swift in Sources */,
 				B1C0000C /* CertificatePinningService.swift in Sources */,
+				B1C00021 /* ReviewPromptService.swift in Sources */,
 				B1D00004 /* Colors.swift in Sources */,
 				B1F00012 /* SkeletonView.swift in Sources */,
 				B1F00013 /* PasswordStrength.swift in Sources */,

--- a/ios/DailyOK.xcodeproj/project.pbxproj
+++ b/ios/DailyOK.xcodeproj/project.pbxproj
@@ -98,6 +98,12 @@
 		B2U00001 /* DailyOKUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2U00001; };
 		B2U00002 /* OwnerFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2U00002; };
 		B2U00003 /* ReceiverFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2U00003; };
+		/* Unit Tests */
+		B3U00001 /* DashboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3U00001; };
+		B3U00002 /* ErrorHandlingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3U00002; };
+		B3U00003 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3U00003; };
+		B3U00004 /* SubscriptionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3U00004; };
+		B3U00005 /* ReviewPromptServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3U00005; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -185,10 +191,25 @@
 		F2U00001 /* DailyOKUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyOKUITests.swift; sourceTree = "<group>"; };
 		F2U00002 /* OwnerFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OwnerFlowTests.swift; sourceTree = "<group>"; };
 		F2U00003 /* ReceiverFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiverFlowTests.swift; sourceTree = "<group>"; };
+		/* Unit Test Product */
+		F1P00003 /* DailyOKTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DailyOKTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		/* Unit Test Files */
+		F3U00001 /* DashboardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModelTests.swift; sourceTree = "<group>"; };
+		F3U00002 /* ErrorHandlingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorHandlingTests.swift; sourceTree = "<group>"; };
+		F3U00003 /* ModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelTests.swift; sourceTree = "<group>"; };
+		F3U00004 /* SubscriptionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionServiceTests.swift; sourceTree = "<group>"; };
+		F3U00005 /* ReviewPromptServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewPromptServiceTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXContainerItemProxy section */
 		CP000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = PR000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = T1000001;
+			remoteInfo = DailyOK;
+		};
+		CP000002 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = PR000001 /* Project object */;
 			proxyType = 1;
@@ -202,6 +223,11 @@
 			isa = PBXTargetDependency;
 			target = T1000001 /* DailyOK */;
 			targetProxy = CP000001 /* PBXContainerItemProxy */;
+		};
+		TD000002 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = T1000001 /* DailyOK */;
+			targetProxy = CP000002 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -222,6 +248,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		D3000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -230,6 +263,7 @@
 			children = (
 				G1000002 /* DailyOK */,
 				G2U00001 /* DailyOKUITests */,
+				G3U00001 /* DailyOKTests */,
 				G1000003 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -254,6 +288,7 @@
 			children = (
 				F1P00001 /* DailyOK.app */,
 				F1P00002 /* DailyOKUITests.xctest */,
+				F1P00003 /* DailyOKTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -431,6 +466,18 @@
 			path = Viewer;
 			sourceTree = "<group>";
 		};
+		G3U00001 /* DailyOKTests */ = {
+			isa = PBXGroup;
+			children = (
+				F3U00001 /* DashboardViewModelTests.swift */,
+				F3U00002 /* ErrorHandlingTests.swift */,
+				F3U00003 /* ModelTests.swift */,
+				F3U00004 /* SubscriptionServiceTests.swift */,
+				F3U00005 /* ReviewPromptServiceTests.swift */,
+			);
+			path = DailyOKTests;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -472,6 +519,23 @@
 			productReference = F1P00002 /* DailyOKUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		T3000001 /* DailyOKTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CL000004 /* Build configuration list for PBXNativeTarget "DailyOKTests" */;
+			buildPhases = (
+				S3000001 /* Sources */,
+				D3000001 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				TD000002 /* PBXTargetDependency */,
+			);
+			name = DailyOKTests;
+			productName = DailyOKTests;
+			productReference = F1P00003 /* DailyOKTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -486,6 +550,10 @@
 						CreatedOnToolsVersion = 15.2;
 					};
 					T2000001 = {
+						CreatedOnToolsVersion = 15.2;
+						TestTargetID = T1000001;
+					};
+					T3000001 = {
 						CreatedOnToolsVersion = 15.2;
 						TestTargetID = T1000001;
 					};
@@ -510,6 +578,7 @@
 			targets = (
 				T1000001 /* DailyOK */,
 				T2000001 /* DailyOKUITests */,
+				T3000001 /* DailyOKTests */,
 			);
 		};
 /* End PBXProject section */
@@ -594,6 +663,18 @@
 				B2U00001 /* DailyOKUITests.swift in Sources */,
 				B2U00002 /* OwnerFlowTests.swift in Sources */,
 				B2U00003 /* ReceiverFlowTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		S3000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B3U00001 /* DashboardViewModelTests.swift in Sources */,
+				B3U00002 /* ErrorHandlingTests.swift in Sources */,
+				B3U00003 /* ModelTests.swift in Sources */,
+				B3U00004 /* SubscriptionServiceTests.swift in Sources */,
+				B3U00005 /* ReviewPromptServiceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -760,6 +841,44 @@
 			};
 			name = Release;
 		};
+		BC000007 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0.6;
+				PRODUCT_BUNDLE_IDENTIFIER = com.wellvo.ios.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DailyOK.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/DailyOK";
+			};
+			name = Debug;
+		};
+		BC000008 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 6;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0.6;
+				PRODUCT_BUNDLE_IDENTIFIER = com.wellvo.ios.tests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/DailyOK.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/DailyOK";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -786,6 +905,15 @@
 			buildConfigurations = (
 				BC000005 /* Debug */,
 				BC000006 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		CL000004 /* Build configuration list for PBXNativeTarget "DailyOKTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				BC000007 /* Debug */,
+				BC000008 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios/DailyOK/Services/ReviewPromptService.swift
+++ b/ios/DailyOK/Services/ReviewPromptService.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Decides *when* to ask for an App Store rating. The actual system prompt is
+/// presented by the views via SwiftUI's `requestReview` environment action;
+/// this service owns only the eligibility logic so it stays pure and testable.
+///
+/// Apple hard-caps the system prompt to 3 per 365 days and may silently drop
+/// requests, so we add stricter gating and only ever ask at a genuinely
+/// positive moment:
+///   • Receiver — after their `checkInThreshold`-th confirmed check-in.
+///   • Owner    — when a receiver reaches an `ownerStreakThreshold`-day streak.
+/// We never ask twice on the same app version, nor within `minDaysBetweenPrompts`
+/// days of a previous ask.
+///
+/// All state is local (UserDefaults) — no schema, API, or on-device-migration
+/// impact. The thresholds, clock, version, and store are injectable for tests.
+@MainActor
+final class ReviewPromptService {
+    static let shared = ReviewPromptService()
+
+    private let checkInThreshold: Int
+    private let ownerStreakThreshold: Int
+    private let minDaysBetweenPrompts: Int
+
+    private let defaults: UserDefaults
+    private let appVersion: String
+    private let now: () -> Date
+
+    init(
+        defaults: UserDefaults = .standard,
+        appVersion: String = ReviewPromptService.bundleShortVersion(),
+        now: @escaping () -> Date = Date.init,
+        checkInThreshold: Int = 5,
+        ownerStreakThreshold: Int = 7,
+        minDaysBetweenPrompts: Int = 120
+    ) {
+        self.defaults = defaults
+        self.appVersion = appVersion
+        self.now = now
+        self.checkInThreshold = checkInThreshold
+        self.ownerStreakThreshold = ownerStreakThreshold
+        self.minDaysBetweenPrompts = minDaysBetweenPrompts
+    }
+
+    private enum Key {
+        static let checkInCount = "reviewPrompt.successfulCheckInCount"
+        static let lastPromptedDate = "reviewPrompt.lastPromptedDate"
+        static let lastPromptedVersion = "reviewPrompt.lastPromptedVersion"
+    }
+
+    // MARK: - Triggers
+
+    /// Record a confirmed (server-persisted) receiver check-in. Returns `true`
+    /// when this check-in makes the user eligible to be asked right now.
+    @discardableResult
+    func registerSuccessfulCheckIn() -> Bool {
+        let count = defaults.integer(forKey: Key.checkInCount) + 1
+        defaults.set(count, forKey: Key.checkInCount)
+        guard count >= checkInThreshold else { return false }
+        return isEligibleToPrompt()
+    }
+
+    /// Whether the owner should be asked now, given the best current receiver
+    /// streak across their family.
+    func shouldPromptForOwnerStreak(maxStreak: Int) -> Bool {
+        guard maxStreak >= ownerStreakThreshold else { return false }
+        return isEligibleToPrompt()
+    }
+
+    /// Shared throttle: never twice on the same app version, and never within
+    /// `minDaysBetweenPrompts` days of the last ask.
+    func isEligibleToPrompt() -> Bool {
+        if defaults.string(forKey: Key.lastPromptedVersion) == appVersion {
+            return false
+        }
+        if let last = defaults.object(forKey: Key.lastPromptedDate) as? Date {
+            let days = Calendar.current.dateComponents([.day], from: last, to: now()).day ?? Int.max
+            if days < minDaysBetweenPrompts { return false }
+        }
+        return true
+    }
+
+    /// Record that the system prompt was just requested. Call immediately after
+    /// invoking the SwiftUI `requestReview` action so we don't ask again this
+    /// version / throttle window.
+    func markPrompted() {
+        defaults.set(now(), forKey: Key.lastPromptedDate)
+        defaults.set(appVersion, forKey: Key.lastPromptedVersion)
+    }
+
+    // MARK: - Helpers
+
+    nonisolated static func bundleShortVersion() -> String {
+        (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "unknown"
+    }
+}

--- a/ios/DailyOK/ViewModels/DashboardViewModel.swift
+++ b/ios/DailyOK/ViewModels/DashboardViewModel.swift
@@ -70,6 +70,10 @@ final class DashboardViewModel: ObservableObject {
     @Published var alerts: [DailyOKAlert] = []
     @Published var isLoading = false
     @Published var errorMessage: String?
+    /// Set true when a milestone (a receiver reaching a multi-day streak) makes
+    /// this a good moment to ask for an App Store rating. The view observes this
+    /// and presents the system prompt, then resets it.
+    @Published var shouldRequestReview = false
 
     private var realtimeChannel: RealtimeChannelV2?
     private var realtimeFamilyId: UUID?
@@ -159,6 +163,12 @@ final class DashboardViewModel: ObservableObject {
 
             receiverCards = cards
             weeklySummary = computeWeeklySummary(checkIns: weeklyCheckIns, receiverCount: receivers.count)
+            // A receiver hitting a strong streak is a high-satisfaction moment —
+            // flag it so the view can ask for a rating (gated + throttled in the
+            // service, so this only fires occasionally and never offline).
+            if ReviewPromptService.shared.shouldPromptForOwnerStreak(maxStreak: cards.map(\.streak).max() ?? 0) {
+                shouldRequestReview = true
+            }
             await loadAlerts(familyId: family.id)
             await subscribeToRealtime(familyId: family.id)
         } catch {

--- a/ios/DailyOK/Views/Owner/DashboardView.swift
+++ b/ios/DailyOK/Views/Owner/DashboardView.swift
@@ -6,6 +6,7 @@ struct DashboardView: View {
     @State private var showFirstReceiverWalkthrough = false
     @EnvironmentObject var appState: AppState
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.requestReview) private var requestReview
 
     private static let walkthroughAutoShownKey = "dailyok.firstReceiverWalkthrough.autoShown"
 
@@ -111,6 +112,15 @@ struct DashboardView: View {
                 if newTab == .dashboard {
                     Task { await viewModel.loadDashboard() }
                 }
+            }
+            // Present the App Store rating prompt when the view model flags a
+            // milestone. The service already gated/throttled the decision; we
+            // just show it and reset the flag.
+            .onChange(of: viewModel.shouldRequestReview) { _, shouldPrompt in
+                guard shouldPrompt else { return }
+                requestReview()
+                ReviewPromptService.shared.markPrompted()
+                viewModel.shouldRequestReview = false
             }
             // Reload when a queued offline check-in syncs (e.g. the owner is
             // also a receiver on the same device) so the card flips from

--- a/ios/DailyOK/Views/Receiver/ReceiverHomeView.swift
+++ b/ios/DailyOK/Views/Receiver/ReceiverHomeView.swift
@@ -5,6 +5,7 @@ struct ReceiverHomeView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @Environment(\.accessibilityReduceMotion) var reduceMotion
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.requestReview) private var requestReview
     @State private var buttonScale: CGFloat = 1.0
     @State private var isPulsing = false
     @State private var showCheckmark = false
@@ -197,6 +198,15 @@ struct ReceiverHomeView: View {
                         animateCheckmark()
                         if viewModel.errorMessage == nil && !viewModel.isOffline {
                             showCelebration = true
+                            // A confirmed, online check-in is a genuine positive
+                            // moment. Ask for an App Store rating only if the user
+                            // has earned it — the service handles the threshold and
+                            // throttling, and lets the celebration play first.
+                            if ReviewPromptService.shared.registerSuccessfulCheckIn() {
+                                try? await Task.sleep(for: .seconds(2))
+                                requestReview()
+                                ReviewPromptService.shared.markPrompted()
+                            }
                         }
                     } else if viewModel.errorMessage != nil {
                         DailyOKHaptics.error()

--- a/ios/DailyOKTests/ReviewPromptServiceTests.swift
+++ b/ios/DailyOKTests/ReviewPromptServiceTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+@testable import DailyOK
+
+/// Tests for ReviewPromptService eligibility + throttling logic.
+///
+/// Note: like the other files in DailyOKTests/, these run only once a unit-test
+/// target is wired into the Xcode project. The service is built to be fully
+/// testable via injected UserDefaults / clock / version so no UI is involved.
+@MainActor
+final class ReviewPromptServiceTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "ReviewPromptServiceTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    private func makeService(
+        now: @escaping () -> Date = Date.init,
+        version: String = "1.0.0",
+        checkInThreshold: Int = 5,
+        ownerStreakThreshold: Int = 7,
+        minDaysBetweenPrompts: Int = 120
+    ) -> ReviewPromptService {
+        ReviewPromptService(
+            defaults: defaults,
+            appVersion: version,
+            now: now,
+            checkInThreshold: checkInThreshold,
+            ownerStreakThreshold: ownerStreakThreshold,
+            minDaysBetweenPrompts: minDaysBetweenPrompts
+        )
+    }
+
+    // MARK: - Check-in threshold
+
+    func testNotEligibleBeforeCheckInThreshold() {
+        let service = makeService(checkInThreshold: 5)
+        for _ in 0..<4 {
+            XCTAssertFalse(service.registerSuccessfulCheckIn(), "Should not prompt before the 5th check-in")
+        }
+    }
+
+    func testEligibleAtCheckInThreshold() {
+        let service = makeService(checkInThreshold: 5)
+        for _ in 0..<4 { _ = service.registerSuccessfulCheckIn() }
+        XCTAssertTrue(service.registerSuccessfulCheckIn(), "The 5th check-in should make the user eligible")
+    }
+
+    // MARK: - Owner streak
+
+    func testOwnerStreakBelowThreshold() {
+        let service = makeService(ownerStreakThreshold: 7)
+        XCTAssertFalse(service.shouldPromptForOwnerStreak(maxStreak: 6))
+    }
+
+    func testOwnerStreakAtThreshold() {
+        let service = makeService(ownerStreakThreshold: 7)
+        XCTAssertTrue(service.shouldPromptForOwnerStreak(maxStreak: 7))
+    }
+
+    // MARK: - Throttling
+
+    func testNotEligibleTwiceOnSameVersion() {
+        let service = makeService(version: "1.2.0")
+        XCTAssertTrue(service.shouldPromptForOwnerStreak(maxStreak: 10))
+        service.markPrompted()
+        XCTAssertFalse(service.shouldPromptForOwnerStreak(maxStreak: 10),
+                       "Should not ask twice on the same app version")
+    }
+
+    func testEligibleAgainOnNewVersionAfterWindow() {
+        let promptDay = Date(timeIntervalSince1970: 1_700_000_000)
+        let v1 = makeService(now: { promptDay }, version: "1.2.0", minDaysBetweenPrompts: 120)
+        XCTAssertTrue(v1.shouldPromptForOwnerStreak(maxStreak: 10))
+        v1.markPrompted()
+
+        // 200 days later, on a new app version → eligible again.
+        let later = promptDay.addingTimeInterval(200 * 86_400)
+        let v2 = makeService(now: { later }, version: "1.3.0", minDaysBetweenPrompts: 120)
+        XCTAssertTrue(v2.shouldPromptForOwnerStreak(maxStreak: 10))
+    }
+
+    func testNotEligibleWithinThrottleWindowEvenOnNewVersion() {
+        let promptDay = Date(timeIntervalSince1970: 1_700_000_000)
+        let v1 = makeService(now: { promptDay }, version: "1.2.0", minDaysBetweenPrompts: 120)
+        XCTAssertTrue(v1.shouldPromptForOwnerStreak(maxStreak: 10))
+        v1.markPrompted()
+
+        // Only 30 days later: even a new version must respect the day window.
+        let soon = promptDay.addingTimeInterval(30 * 86_400)
+        let v2 = makeService(now: { soon }, version: "1.3.0", minDaysBetweenPrompts: 120)
+        XCTAssertFalse(v2.shouldPromptForOwnerStreak(maxStreak: 10))
+    }
+}

--- a/screenshots/dist/capture.js
+++ b/screenshots/dist/capture.js
@@ -39,7 +39,7 @@ const fs = __importStar(require("fs"));
 const devices_1 = require("./devices");
 const screens_1 = require("./screens");
 /**
- * App Store Screenshot Generator for DailyOK
+ * App Store Screenshot Generator for Daily OK
  *
  * Generates screenshots at exact App Store required resolutions
  * by rendering HTML mockups of each app screen in a headless browser.
@@ -56,9 +56,13 @@ const SCREEN_IDS = [
     'family-management', // 6. Family member management
     'plan-selection', // 7. Plan selection / pricing
 ];
-const OUTPUT_DIR = path.resolve(__dirname, '..', 'output');
+// Variant: 'v1' (bare app screens, original) or 'v2' (marketing captions).
+// v2 writes to a separate folder so the original v1 set is never overwritten —
+// switch the App Store Connect upload between them to roll forward/back.
+const VARIANT = process.argv.find(a => a.startsWith('--variant='))?.split('=')[1] === 'v2' ? 'v2' : 'v1';
+const OUTPUT_DIR = path.resolve(__dirname, '..', VARIANT === 'v2' ? 'output-v2' : 'output');
 async function captureScreen(page, device, screenId) {
-    const html = (0, screens_1.getScreenHTML)(screenId, device);
+    const html = (0, screens_1.getScreenHTML)(screenId, device, VARIANT);
     const deviceDir = path.join(OUTPUT_DIR, device.slug);
     fs.mkdirSync(deviceDir, { recursive: true });
     // Set viewport to logical size
@@ -95,7 +99,8 @@ async function main() {
         screens: args.filter(a => a.startsWith('--screen=')).map(a => a.split('=')[1]),
         deviceSlugs: args.filter(a => a.startsWith('--device=')).map(a => a.split('=')[1]),
     };
-    console.log('=== DailyOK App Store Screenshot Generator ===\n');
+    console.log(`=== Daily OK App Store Screenshot Generator (variant: ${VARIANT}) ===\n`);
+    console.log(`Output dir: ${OUTPUT_DIR}\n`);
     // Filter devices
     let targetDevices = devices_1.devices;
     if (opts.requiredOnly) {

--- a/screenshots/dist/screens.js
+++ b/screenshots/dist/screens.js
@@ -1,11 +1,89 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.getScreenHTML = getScreenHTML;
-/** Returns the full HTML page for a given screen, sized to the device's logical viewport */
-function getScreenHTML(screenId, device) {
+/**
+ * v2 marketing captions — a bold value-prop headline rendered above the
+ * device frame. The first 2–3 screenshots show in App Store search results
+ * without a tap, so these sell the value instantly. See docs/ASO_STRATEGY.md.
+ * `\n` becomes a line break in the headline.
+ */
+const CAPTIONS = {
+    'receiver-checkin': { headline: "Know they're OK —\nevery single day", sub: 'One tap is all it takes' },
+    'receiver-done': { headline: "One tap.\nThey're safe.", sub: 'Your family knows instantly' },
+    'mood-selector': { headline: 'A quick mood check, too', sub: 'Notice changes before they grow' },
+    'owner-dashboard': { headline: 'See everyone\nat a glance', sub: 'Get alerted if anyone misses a check-in' },
+    'history-heatmap': { headline: 'Spot worrying\npatterns early', sub: 'Streaks, trends & check-in history' },
+    'family-management': { headline: 'No tracking.\nNo surveillance.', sub: "Just a daily 'I'm OK' — ages 13 to 95" },
+    'plan-selection': { headline: 'Start free.\nCancel anytime.', sub: 'One plan covers the whole family' },
+};
+/**
+ * Returns the full HTML page for a given screen, sized to the device's logical viewport.
+ * `variant` 'v1' (default) renders the bare app screen (original, byte-for-byte preserved).
+ * `variant` 'v2' wraps it in a marketing frame with a caption headline (see CAPTIONS).
+ */
+function getScreenHTML(screenId, device, variant = 'v1') {
     const isIPad = device.slug.startsWith('ipad');
     const isLegacy = device.cornerRadius === 0; // iPhone 8 Plus style
     const contentHeight = device.logicalHeight - device.statusBar - device.homeIndicator;
+    const isV2 = variant === 'v2';
+    // Shared phone markup (status bar + app screen + home indicator). In v1 this
+    // is the whole body; in v2 it lives inside a scaled-down .device-frame.
+    const phoneInner = `
+    ${getStatusBarHTML(device)}
+    <div class="screen-content">
+      ${getScreenContent(screenId, device)}
+    </div>
+    ${device.homeIndicator > 0 ? `<div class="home-indicator-bar"><div class="home-indicator-pill"></div></div>` : ''}
+  `;
+    // v2 marketing-frame geometry: caption headline above a scaled device.
+    const lw = device.logicalWidth;
+    const lh = device.logicalHeight;
+    const frameScale = isLegacy ? 0.82 : 0.84;
+    const frameW = Math.round(lw * frameScale);
+    const frameH = Math.round(lh * frameScale);
+    const frameRadius = Math.round((device.cornerRadius || 28) * frameScale);
+    const bottomGap = Math.round(lh * 0.03);
+    const captionH = lh - frameH - bottomGap;
+    const captionFont = Math.round(lw * (isIPad ? 0.05 : 0.075));
+    const subFont = Math.round(captionFont * 0.5);
+    const cap = CAPTIONS[screenId] || { headline: '', sub: '' };
+    const v2Styles = isV2 ? `
+    html, body { background: transparent; }
+    .marketing {
+      width: ${lw}px; height: ${lh}px;
+      display: flex; flex-direction: column; align-items: center;
+      background: linear-gradient(180deg, #F0FDF4 0%, #DCFCE7 100%);
+    }
+    .caption {
+      height: ${captionH}px; width: 100%;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      text-align: center; padding: 0 ${Math.round(lw * 0.08)}px;
+    }
+    .caption h2 { font-size: ${captionFont}px; line-height: 1.12; font-weight: 800; color: #1E293B; letter-spacing: -0.5px; }
+    .caption p { margin-top: ${Math.round(captionFont * 0.35)}px; font-size: ${subFont}px; font-weight: 600; color: #22A85C; }
+    .device-frame {
+      width: ${frameW}px; height: ${frameH}px;
+      border-radius: ${frameRadius}px; overflow: hidden; position: relative;
+      background: #FFFFFF; flex-shrink: 0;
+      box-shadow: 0 24px 60px rgba(16,24,40,0.18), 0 4px 16px rgba(16,24,40,0.10);
+    }
+    .phone {
+      width: ${lw}px; height: ${lh}px;
+      transform: scale(${frameScale}); transform-origin: top left;
+      background: #FFFFFF; overflow: hidden; position: relative;
+    }
+  ` : '';
+    const v2Body = `
+    <div class="marketing">
+      <div class="caption">
+        <h2>${cap.headline.replace(/\n/g, '<br>')}</h2>
+        <p>${cap.sub}</p>
+      </div>
+      <div class="device-frame">
+        <div class="phone">${phoneInner}</div>
+      </div>
+    </div>
+  `;
     const base = `
 <!DOCTYPE html>
 <html lang="en">
@@ -132,15 +210,12 @@ function getScreenHTML(screenId, device) {
     margin-bottom: 12px;
   }
 
+  ${v2Styles}
   ${getScreenStyles(screenId, device)}
 </style>
 </head>
 <body>
-  ${getStatusBarHTML(device)}
-  <div class="screen-content">
-    ${getScreenContent(screenId, device)}
-  </div>
-  ${device.homeIndicator > 0 ? `<div class="home-indicator-bar"><div class="home-indicator-pill"></div></div>` : ''}
+  ${isV2 ? v2Body : phoneInner}
 </body>
 </html>`;
     return base;
@@ -814,44 +889,43 @@ function getScreenContent(screenId, device) {
         <div class="plan-screen">
           <div class="plan-subheading">Start with a free trial. Cancel anytime.</div>
 
-          <div class="plan-card">
-            <div class="plan-name-row">
-              <div class="plan-name">Free</div>
-              <div class="plan-price">$0 <span>/month</span></div>
-            </div>
-            <ul class="plan-features-list">
-              <li class="plan-feature"><span class="check">✓</span> 1 Receiver</li>
-              <li class="plan-feature"><span class="check">✓</span> Daily check-ins</li>
-              <li class="plan-feature"><span class="check">✓</span> Basic escalation</li>
-              <li class="plan-feature"><span class="check">✓</span> 7-day history</li>
-            </ul>
-          </div>
-
           <div class="plan-card highlighted">
             <div class="plan-popular">Most Popular</div>
             <div class="plan-name-row">
-              <div class="plan-name">Family</div>
-              <div class="plan-price">$4.99 <span>/month</span></div>
+              <div class="plan-name">Caregiver</div>
+              <div class="plan-price">$3.99 <span>/month</span></div>
             </div>
             <ul class="plan-features-list">
-              <li class="plan-feature"><span class="check">✓</span> 2 Receivers, 2 Viewers</li>
-              <li class="plan-feature"><span class="check">✓</span> Custom schedules</li>
-              <li class="plan-feature"><span class="check">✓</span> On-demand check-ins</li>
-              <li class="plan-feature"><span class="check">✓</span> Mood tracking</li>
+              <li class="plan-feature"><span class="check">✓</span> 1 Receiver, 3 Viewers</li>
+              <li class="plan-feature"><span class="check">✓</span> Daily + on-demand check-ins</li>
+              <li class="plan-feature"><span class="check">✓</span> Full escalation chain</li>
+              <li class="plan-feature"><span class="check">✓</span> Mood + pattern alerts</li>
               <li class="plan-feature"><span class="check">✓</span> 90-day history</li>
-              <li class="plan-feature"><span class="check">✓</span> Pattern alerts</li>
+            </ul>
+          </div>
+
+          <div class="plan-card">
+            <div class="plan-name-row">
+              <div class="plan-name">Family</div>
+              <div class="plan-price">$6.99 <span>/month</span></div>
+            </div>
+            <ul class="plan-features-list">
+              <li class="plan-feature"><span class="check">✓</span> 3 Receivers, 5 Viewers</li>
+              <li class="plan-feature"><span class="check">✓</span> Everything in Caregiver</li>
+              <li class="plan-feature"><span class="check">✓</span> Clinician PDF export</li>
+              <li class="plan-feature"><span class="check">✓</span> 1-year history</li>
+              <li class="plan-feature"><span class="check">✓</span> Kid mode</li>
             </ul>
           </div>
 
           <div class="plan-card">
             <div class="plan-name-row">
               <div class="plan-name">Family+</div>
-              <div class="plan-price">$7.99 <span>/month</span></div>
+              <div class="plan-price">$9.99 <span>/month</span></div>
             </div>
             <ul class="plan-features-list">
-              <li class="plan-feature"><span class="check">✓</span> 5 Receivers, 5 Viewers</li>
+              <li class="plan-feature"><span class="check">✓</span> 6 Receivers, 10 Viewers</li>
               <li class="plan-feature"><span class="check">✓</span> Critical Alerts (bypass DND)</li>
-              <li class="plan-feature"><span class="check">✓</span> PDF reports</li>
               <li class="plan-feature"><span class="check">✓</span> Unlimited history</li>
               <li class="plan-feature"><span class="check">✓</span> Priority support</li>
             </ul>

--- a/screenshots/package.json
+++ b/screenshots/package.json
@@ -8,6 +8,8 @@
     "capture": "tsc && node dist/capture.js",
     "capture:required": "tsc && node dist/capture.js --required-only",
     "capture:screen": "tsc && node dist/capture.js",
+    "capture:v2": "tsc && node dist/capture.js --variant=v2",
+    "capture:v2:required": "tsc && node dist/capture.js --variant=v2 --required-only",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/screenshots/src/capture.ts
+++ b/screenshots/src/capture.ts
@@ -24,7 +24,12 @@ const SCREEN_IDS = [
   'plan-selection',     // 7. Plan selection / pricing
 ]
 
-const OUTPUT_DIR = path.resolve(__dirname, '..', 'output')
+// Variant: 'v1' (bare app screens, original) or 'v2' (marketing captions).
+// v2 writes to a separate folder so the original v1 set is never overwritten —
+// switch the App Store Connect upload between them to roll forward/back.
+const VARIANT: 'v1' | 'v2' =
+  process.argv.find(a => a.startsWith('--variant='))?.split('=')[1] === 'v2' ? 'v2' : 'v1'
+const OUTPUT_DIR = path.resolve(__dirname, '..', VARIANT === 'v2' ? 'output-v2' : 'output')
 
 interface CaptureOptions {
   /** Only capture required devices */
@@ -40,7 +45,7 @@ async function captureScreen(
   device: DeviceSpec,
   screenId: string,
 ): Promise<string> {
-  const html = getScreenHTML(screenId, device)
+  const html = getScreenHTML(screenId, device, VARIANT)
   const deviceDir = path.join(OUTPUT_DIR, device.slug)
   fs.mkdirSync(deviceDir, { recursive: true })
 
@@ -85,7 +90,8 @@ async function main() {
     deviceSlugs: args.filter(a => a.startsWith('--device=')).map(a => a.split('=')[1]),
   }
 
-  console.log('=== Daily OK App Store Screenshot Generator ===\n')
+  console.log(`=== Daily OK App Store Screenshot Generator (variant: ${VARIANT}) ===\n`)
+  console.log(`Output dir: ${OUTPUT_DIR}\n`)
 
   // Filter devices
   let targetDevices = devices

--- a/screenshots/src/screens.ts
+++ b/screenshots/src/screens.ts
@@ -1,10 +1,93 @@
 import { DeviceSpec } from './devices'
 
-/** Returns the full HTML page for a given screen, sized to the device's logical viewport */
-export function getScreenHTML(screenId: string, device: DeviceSpec): string {
+/**
+ * v2 marketing captions — a bold value-prop headline rendered above the
+ * device frame. The first 2–3 screenshots show in App Store search results
+ * without a tap, so these sell the value instantly. See docs/ASO_STRATEGY.md.
+ * `\n` becomes a line break in the headline.
+ */
+const CAPTIONS: Record<string, { headline: string; sub: string }> = {
+  'receiver-checkin':  { headline: "Know they're OK —\nevery single day", sub: 'One tap is all it takes' },
+  'receiver-done':     { headline: "One tap.\nThey're safe.",            sub: 'Your family knows instantly' },
+  'mood-selector':     { headline: 'A quick mood check, too',            sub: 'Notice changes before they grow' },
+  'owner-dashboard':   { headline: 'See everyone\nat a glance',          sub: 'Get alerted if anyone misses a check-in' },
+  'history-heatmap':   { headline: 'Spot worrying\npatterns early',      sub: 'Streaks, trends & check-in history' },
+  'family-management': { headline: 'No tracking.\nNo surveillance.',     sub: "Just a daily 'I'm OK' — ages 13 to 95" },
+  'plan-selection':    { headline: 'Start free.\nCancel anytime.',       sub: 'One plan covers the whole family' },
+}
+
+/**
+ * Returns the full HTML page for a given screen, sized to the device's logical viewport.
+ * `variant` 'v1' (default) renders the bare app screen (original, byte-for-byte preserved).
+ * `variant` 'v2' wraps it in a marketing frame with a caption headline (see CAPTIONS).
+ */
+export function getScreenHTML(screenId: string, device: DeviceSpec, variant: 'v1' | 'v2' = 'v1'): string {
   const isIPad = device.slug.startsWith('ipad')
   const isLegacy = device.cornerRadius === 0 // iPhone 8 Plus style
   const contentHeight = device.logicalHeight - device.statusBar - device.homeIndicator
+  const isV2 = variant === 'v2'
+
+  // Shared phone markup (status bar + app screen + home indicator). In v1 this
+  // is the whole body; in v2 it lives inside a scaled-down .device-frame.
+  const phoneInner = `
+    ${getStatusBarHTML(device)}
+    <div class="screen-content">
+      ${getScreenContent(screenId, device)}
+    </div>
+    ${device.homeIndicator > 0 ? `<div class="home-indicator-bar"><div class="home-indicator-pill"></div></div>` : ''}
+  `
+
+  // v2 marketing-frame geometry: caption headline above a scaled device.
+  const lw = device.logicalWidth
+  const lh = device.logicalHeight
+  const frameScale = isLegacy ? 0.82 : 0.84
+  const frameW = Math.round(lw * frameScale)
+  const frameH = Math.round(lh * frameScale)
+  const frameRadius = Math.round((device.cornerRadius || 28) * frameScale)
+  const bottomGap = Math.round(lh * 0.03)
+  const captionH = lh - frameH - bottomGap
+  const captionFont = Math.round(lw * (isIPad ? 0.05 : 0.075))
+  const subFont = Math.round(captionFont * 0.5)
+  const cap = CAPTIONS[screenId] || { headline: '', sub: '' }
+
+  const v2Styles = isV2 ? `
+    html, body { background: transparent; }
+    .marketing {
+      width: ${lw}px; height: ${lh}px;
+      display: flex; flex-direction: column; align-items: center;
+      background: linear-gradient(180deg, #F0FDF4 0%, #DCFCE7 100%);
+    }
+    .caption {
+      height: ${captionH}px; width: 100%;
+      display: flex; flex-direction: column; align-items: center; justify-content: center;
+      text-align: center; padding: 0 ${Math.round(lw * 0.08)}px;
+    }
+    .caption h2 { font-size: ${captionFont}px; line-height: 1.12; font-weight: 800; color: #1E293B; letter-spacing: -0.5px; }
+    .caption p { margin-top: ${Math.round(captionFont * 0.35)}px; font-size: ${subFont}px; font-weight: 600; color: #22A85C; }
+    .device-frame {
+      width: ${frameW}px; height: ${frameH}px;
+      border-radius: ${frameRadius}px; overflow: hidden; position: relative;
+      background: #FFFFFF; flex-shrink: 0;
+      box-shadow: 0 24px 60px rgba(16,24,40,0.18), 0 4px 16px rgba(16,24,40,0.10);
+    }
+    .phone {
+      width: ${lw}px; height: ${lh}px;
+      transform: scale(${frameScale}); transform-origin: top left;
+      background: #FFFFFF; overflow: hidden; position: relative;
+    }
+  ` : ''
+
+  const v2Body = `
+    <div class="marketing">
+      <div class="caption">
+        <h2>${cap.headline.replace(/\n/g, '<br>')}</h2>
+        <p>${cap.sub}</p>
+      </div>
+      <div class="device-frame">
+        <div class="phone">${phoneInner}</div>
+      </div>
+    </div>
+  `
 
   const base = `
 <!DOCTYPE html>
@@ -132,15 +215,12 @@ export function getScreenHTML(screenId: string, device: DeviceSpec): string {
     margin-bottom: 12px;
   }
 
+  ${v2Styles}
   ${getScreenStyles(screenId, device)}
 </style>
 </head>
 <body>
-  ${getStatusBarHTML(device)}
-  <div class="screen-content">
-    ${getScreenContent(screenId, device)}
-  </div>
-  ${device.homeIndicator > 0 ? `<div class="home-indicator-bar"><div class="home-indicator-pill"></div></div>` : ''}
+  ${isV2 ? v2Body : phoneInner}
 </body>
 </html>`
   return base


### PR DESCRIPTION
Adds docs/ASO_STRATEGY.md — a prioritized plan to lift App Store
impressions and organic installs:
- Diagnoses why impressions are low (weak name/subtitle keyword
  weight, inefficient keyword field, single locale, caption-less
  screenshots, no Search Ads, thin ratings)
- New character-counted Name/Subtitle/Keywords ready to paste
- en-GB + en-AU keyword localization expansion (US-indexed)
- Screenshot caption overlays, PPO A/B tests, Custom Product Pages
- SKStoreReviewController ratings engine + In-App Events
- Apple Search Ads campaign structure (brand/conquest/generic/discovery)
- Competitive positioning vs Snug, Life360, medical-alert incumbents
- 30/60/90 rollout, KPIs, and CLAUDE.md compliance notes