### PR TITLE
hotfix: A2P 10DLC CTA compliance for Twilio campaign resubmission

### DIFF
--- a/ios/DailyOK/Views/Owner/FamilyView.swift
+++ b/ios/DailyOK/Views/Owner/FamilyView.swift
@@ -419,6 +419,12 @@ struct InviteReceiverSheet: View {
                         Text("You can customize the schedule later (weekday/weekend, per-day, pause, etc.) from their settings.")
                     }
 
+                    Section {
+                        Text("By tapping Send Invite, you confirm you have this person's consent to receive a one-time SMS from Daily OK with a link to download the app. Msg & data rates may apply. They can reply STOP to opt out or HELP for assistance. See our Privacy Policy (dailyok.net/privacy) and Terms of Use (dailyok.net/terms).")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
                     if let error = errorMessage {
                         Section {
                             Text(error)

--- a/ios/DailyOK/Views/Settings/ReceiverSettingsView.swift
+++ b/ios/DailyOK/Views/Settings/ReceiverSettingsView.swift
@@ -228,7 +228,7 @@ struct ReceiverSettingsView: View {
             } header: {
                 Text("SMS Escalation")
             } footer: {
-                Text("Send an SMS to you and viewers if push notifications fail during escalation. Requires a phone number on your account.")
+                Text("When enabled, an SMS alert is sent to you and viewers if push notifications fail during escalation. Requires a phone number on your account. Msg & data rates may apply. Reply STOP to any message to opt out, or HELP for assistance.")
             }
 
             // Mood Tracking

--- a/website/src/pages/Privacy.tsx
+++ b/website/src/pages/Privacy.tsx
@@ -13,7 +13,7 @@ export default function Privacy() {
       <div className="container">
         <div className="legal-content">
           <h1>Privacy Policy</h1>
-          <p className="legal-updated">Last updated: April 13, 2026</p>
+          <p className="legal-updated">Last updated: June 15, 2026</p>
 
           <section>
             <h2>Introduction</h2>
@@ -126,8 +126,9 @@ export default function Privacy() {
             <h2>SMS Messaging (A2P 10DLC)</h2>
             <p>
               Daily OK uses SMS for two purposes only. We do not use phone numbers
-              for marketing, and we do not share or sell phone numbers or opt-in
-              information with third parties for promotional purposes.
+              for marketing. Mobile opt-in data, phone numbers, and SMS consent
+              information will never be shared with or sold to any third party
+              for any purpose.
             </p>
             <h3>Message types and consent</h3>
             <ul>


### PR DESCRIPTION
## Summary

Fixes the three concrete issues causing the Twilio 10DLC campaign to be rejected with error 30909 (CTA/Message Flow).

- **Privacy policy**: removes the weak `for promotional purposes` qualifier from the SMS no-sharing statement — replaces with absolute carrier-required language: *"Mobile opt-in data, phone numbers, and SMS consent information will never be shared with or sold to any third party for any purpose."*
- **InviteReceiverSheet (iOS)**: adds a visible consent disclosure section before the Send Invite button — program name, one-time SMS notice, Msg & data rates, STOP/HELP keywords, links to Privacy + Terms.
- **ReceiverSettingsView SMS toggle (iOS)**: adds Msg & data rates and STOP/HELP disclosure to the footer at the point of explicit opt-in.

## What this does NOT change

- Actual SMS message content (already says "Daily OK" everywhere — the "Wellvo" was only in the Twilio dashboard sample #2 typed manually, not in the code)
- Any API or database shape

## Test plan

- [ ] Website: verify `dailyok.net/privacy#sms` shows the updated no-sharing language
- [ ] iOS: Invite Receiver sheet shows the disclosure above Send Invite
- [ ] iOS: ReceiverSettingsView SMS toggle footer shows Msg & data rates + STOP/HELP
- [ ] Twilio: resubmit campaign with corrected samples and updated consent description

🤖 Generated with [Claude Code](https://claude.com/claude-code)