### PR TITLE
fix: resolve iOS CI signing failures for all targets

### DIFF
--- a/.github/workflows/ios-build-deploy.yml
+++ b/.github/workflows/ios-build-deploy.yml
@@ -91,13 +91,13 @@ jobs:
 
       - name: Inject build configuration
         run: |
-          # Write code signing config to xcconfig (these values are safe for xcconfig)
+          # Only write non-signing config to xcconfig.
+          # CODE_SIGN_STYLE / DEVELOPMENT_TEAM / PROVISIONING_PROFILE_SPECIFIER are
+          # passed as xcodebuild build-setting overrides so they apply to ALL targets
+          # (Watch, WatchWidgets, Widgets) — not just the main app target that
+          # references this xcconfig.
           {
             echo "// Daily OK Build Configuration (CI-generated)"
-            echo "CODE_SIGN_STYLE = Manual"
-            echo "CODE_SIGN_IDENTITY = Apple Distribution"
-            echo "DEVELOPMENT_TEAM = ${{ env.APPLE_TEAM_ID }}"
-            echo "PROVISIONING_PROFILE_SPECIFIER = ${{ env.PROVISIONING_PROFILE_NAME }}"
             echo "PRODUCT_BUNDLE_IDENTIFIER = com.wellvo.ios"
           } > ios/DailyOK/BuildConfig.xcconfig
 
@@ -124,16 +124,34 @@ jobs:
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
           echo "🏷️ Version: $VERSION ($BUILD_NUMBER)"
 
+      - name: Setup App Store Connect API key
+        run: |
+          mkdir -p ~/.private_keys
+          KEY_FILE=~/.private_keys/AuthKey_${{ env.ASC_KEY_ID }}.p8
+          echo -n "${{ env.ASC_PRIVATE_KEY }}" | sed 's/\\n/\n/g' > "$KEY_FILE"
+          # Verify the key file looks like a valid PEM
+          echo "Key file first line: $(head -1 "$KEY_FILE")"
+          echo "Key file line count: $(wc -l < "$KEY_FILE")"
+
       - name: Build and archive
         working-directory: ios
         run: |
           set -o pipefail
+          # -allowProvisioningUpdates lets Xcode auto-provision ALL targets
+          # (Watch, WatchWidgets, Widgets) using the ASC API key, eliminating
+          # the need to manually install per-target provisioning profiles in CI.
           xcodebuild archive \
             -project DailyOK.xcodeproj \
             -scheme DailyOK \
             -configuration Release \
             -archivePath $RUNNER_TEMP/DailyOK.xcarchive \
             -destination "generic/platform=iOS" \
+            -allowProvisioningUpdates \
+            -authenticationKeyPath ~/.private_keys/AuthKey_${{ env.ASC_KEY_ID }}.p8 \
+            -authenticationKeyID ${{ env.ASC_KEY_ID }} \
+            -authenticationKeyIssuerID ${{ env.ASC_ISSUER_ID }} \
+            CODE_SIGN_STYLE=Automatic \
+            DEVELOPMENT_TEAM="${{ env.APPLE_TEAM_ID }}" \
             MARKETING_VERSION="${{ env.APP_VERSION }}" \
             CURRENT_PROJECT_VERSION="${{ env.BUILD_NUMBER }}" \
             | xcbeautify
@@ -162,24 +180,12 @@ jobs:
               <key>destination</key>
               <string>upload</string>
               <key>signingStyle</key>
-              <string>manual</string>
-              <key>provisioningProfiles</key>
-              <dict>
-                  <key>com.wellvo.ios</key>
-                  <string>${{ env.PROVISIONING_PROFILE_NAME }}</string>
-              </dict>
+              <string>automatic</string>
+              <key>manageAppVersionAndBuildNumber</key>
+              <false/>
           </dict>
           </plist>
           EOF
-
-      - name: Setup App Store Connect API key
-        run: |
-          mkdir -p ~/.private_keys
-          KEY_FILE=~/.private_keys/AuthKey_${{ env.ASC_KEY_ID }}.p8
-          echo -n "${{ env.ASC_PRIVATE_KEY }}" | sed 's/\\n/\n/g' > "$KEY_FILE"
-          # Verify the key file looks like a valid PEM
-          echo "Key file first line: $(head -1 "$KEY_FILE")"
-          echo "Key file line count: $(wc -l < "$KEY_FILE")"
 
       - name: Export IPA
         run: |

--- a/ios/DailyOK/DailyOK.entitlements
+++ b/ios/DailyOK/DailyOK.entitlements
@@ -18,7 +18,5 @@
 	<true/>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
-	<key>com.apple.developer.healthkit.access</key>
-	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- Removes `com.apple.developer.healthkit.access` from `DailyOK.entitlements` — this Verifiable Health Records key requires explicit Apple approval and is not needed; `HealthService` only reads step count, which is covered by `com.apple.developer.healthkit = true` alone
- Strips code-signing settings from `BuildConfig.xcconfig`; they only reached the main app target, leaving Watch/WatchWidgets/Widgets without a `DEVELOPMENT_TEAM` (the "requires a development team" errors)
- Moves ASC API key setup before the archive step
- Adds `-allowProvisioningUpdates` to `xcodebuild archive` with the ASC API key; Xcode auto-provisions all extension targets, eliminating per-target manual profile installs
- Passes `CODE_SIGN_STYLE=Automatic` and `DEVELOPMENT_TEAM` as xcodebuild build-setting overrides (apply to every target) instead of via xcconfig
- Switches `ExportOptions.plist` to `signingStyle=automatic` to match

## Errors fixed

| Error | Fix |
|---|---|
| `healthkit.access requires Apple approval` | Removed the entitlement key |
| `DailyOKWatch/WatchWidgets requires a development team` | `DEVELOPMENT_TEAM` now on command line, applies to all targets |
| `DailyOKWidgets conflicting provisioning settings` | Removed `CODE_SIGN_STYLE=Manual` from xcconfig |
| Profile missing App Groups / HealthKit | `-allowProvisioningUpdates` auto-creates correct profiles via ASC API |

## Note

Ensure `group.com.wellvo.ios` App Group and HealthKit are enabled on the `com.wellvo.ios` App ID in the Apple Developer Portal. With `-allowProvisioningUpdates` Xcode can register capabilities automatically, but the App Group identifier must exist in the portal first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)