### PR TITLE
hotfix: switch iOS CI archive to Manual signing with Apple Distribution

### DIFF
--- a/.github/workflows/ios-build-deploy.yml
+++ b/.github/workflows/ios-build-deploy.yml
@@ -91,13 +91,13 @@ jobs:
 
       - name: Inject build configuration
         run: |
-          # Only write non-signing config to xcconfig.
-          # CODE_SIGN_STYLE / DEVELOPMENT_TEAM / PROVISIONING_PROFILE_SPECIFIER are
-          # passed as xcodebuild build-setting overrides so they apply to ALL targets
-          # (Watch, WatchWidgets, Widgets) — not just the main app target that
-          # references this xcconfig.
+          # PROVISIONING_PROFILE_SPECIFIER in xcconfig applies only to the main app
+          # target (the only target that references BuildConfig.xcconfig).
+          # Signing style/identity/team are set as xcodebuild command-line overrides
+          # so they apply to ALL targets (Watch, WatchWidgets, Widgets).
           {
             echo "// Daily OK Build Configuration (CI-generated)"
+            echo "PROVISIONING_PROFILE_SPECIFIER = ${{ env.PROVISIONING_PROFILE_NAME }}"
             echo "PRODUCT_BUNDLE_IDENTIFIER = com.wellvo.ios"
           } > ios/DailyOK/BuildConfig.xcconfig
 
@@ -137,9 +137,11 @@ jobs:
         working-directory: ios
         run: |
           set -o pipefail
-          # -allowProvisioningUpdates lets Xcode auto-provision ALL targets
-          # (Watch, WatchWidgets, Widgets) using the ASC API key, eliminating
-          # the need to manually install per-target provisioning profiles in CI.
+          # Manual signing with Apple Distribution certificate applies to ALL targets
+          # via xcodebuild build-setting overrides (xcconfig only reaches main app).
+          # -allowProvisioningUpdates downloads existing Distribution profiles for
+          # extension targets (Watch, WatchWidgets, Widgets) without registering new
+          # App IDs or creating Development certificates.
           xcodebuild archive \
             -project DailyOK.xcodeproj \
             -scheme DailyOK \
@@ -150,7 +152,8 @@ jobs:
             -authenticationKeyPath ~/.private_keys/AuthKey_${{ env.ASC_KEY_ID }}.p8 \
             -authenticationKeyID ${{ env.ASC_KEY_ID }} \
             -authenticationKeyIssuerID ${{ env.ASC_ISSUER_ID }} \
-            CODE_SIGN_STYLE=Automatic \
+            CODE_SIGN_STYLE=Manual \
+            CODE_SIGN_IDENTITY="Apple Distribution" \
             DEVELOPMENT_TEAM="${{ env.APPLE_TEAM_ID }}" \
             MARKETING_VERSION="${{ env.APP_VERSION }}" \
             CURRENT_PROJECT_VERSION="${{ env.BUILD_NUMBER }}" \
@@ -180,9 +183,12 @@ jobs:
               <key>destination</key>
               <string>upload</string>
               <key>signingStyle</key>
-              <string>automatic</string>
-              <key>manageAppVersionAndBuildNumber</key>
-              <false/>
+              <string>manual</string>
+              <key>provisioningProfiles</key>
+              <dict>
+                  <key>com.wellvo.ios</key>
+                  <string>${{ env.PROVISIONING_PROFILE_NAME }}</string>
+              </dict>
           </dict>
           </plist>
           EOF


### PR DESCRIPTION
## Problem

`CODE_SIGN_STYLE=Automatic` (added in PR #202) caused two cascading errors on every CI run:

1. **"Revoke certificate" error** — Automatic signing asks Xcode to manage Development certificates. The CI runner only has the Distribution certificate installed; no Development private key is present, so Xcode errors trying to reconcile the stale Dev cert Apple already has registered for the runner machine.

2. **"com.wellvo.ios.watchkitapp.complication cannot be registered"** — Automatic signing tries to register App IDs it doesn't find. Apple blocks new registrations under the legacy `*.watchkitapp.complication` naming convention, so this fails unconditionally.

## Fix

Switch to `CODE_SIGN_STYLE=Manual` + `CODE_SIGN_IDENTITY="Apple Distribution"` passed as **xcodebuild command-line overrides** (which apply to all targets: main app, DailyOKWidgets, DailyOKWatch, DailyOKWatchWidgets).

Keep `-allowProvisioningUpdates` with the ASC API key — with Manual signing, this only **downloads existing** Distribution profiles from the portal; it never creates App IDs or Development certificates.

Add `PROVISIONING_PROFILE_SPECIFIER` back to `BuildConfig.xcconfig` so the main app target resolves its Distribution profile by name. Extension targets have no specifier set, so Xcode searches by bundle ID + certificate match and downloads from the portal via `-allowProvisioningUpdates`.

## What's still needed (user action)

If the CI fails after this merge with "No provisioning profiles found" for any extension target, it means a Distribution provisioning profile doesn't exist in Apple Developer Portal for that bundle ID. Create them at developer.apple.com → Certificates, Identifiers & Profiles → Profiles:

- `com.wellvo.ios.DailyOKWidgets` → iOS Distribution profile
- `com.wellvo.ios.watchkitapp` → watchOS Distribution profile  
- `com.wellvo.ios.watchkitapp.complication` → watchOS Distribution profile

Once created, `-allowProvisioningUpdates` will download them automatically — no Infisical changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)