### PR TITLE
CI(ios): patch NotificationService target for manual Distribution sig…

### DIFF
--- a/.github/scripts/patch_signing.py
+++ b/.github/scripts/patch_signing.py
@@ -2,22 +2,47 @@
 """Patch project.pbxproj Release configs for manual Distribution signing in CI.
 
 Usage:
-    python3 patch_signing.py <main_uuid> <widgets_uuid> <watch_uuid> <watch_widgets_uuid>
+    python3 patch_signing.py <main_uuid> <widgets_uuid> <watch_uuid> \
+        <watch_widgets_uuid> <nse_uuid>
 
 Writes CODE_SIGN_STYLE=Manual, CODE_SIGN_IDENTITY="Apple Distribution", and
-PROVISIONING_PROFILE_SPECIFIER=<uuid> into the four app-target Release build
-configurations (BC000004/10/12/14).  SPM package targets live in DerivedData
+PROVISIONING_PROFILE_SPECIFIER=<uuid> into the five app-target Release build
+configurations (BC000004/10/12/14/16).  SPM package targets live in DerivedData
 (not in project.pbxproj), so they keep their own Automatic signing and never
 conflict with the Distribution identity.
+
+Every embedded target with a distinct bundle id needs its own profile.  The
+NotificationService extension (com.wellvo.ios.NotificationService, BC000016) was
+added later than the original four; if its config is left on Automatic signing
+the archive fails with "No profiles ... were found ... Automatic signing is
+disabled" because CI runs xcodebuild without -allowProvisioningUpdates.
 """
 import sys
+
+if len(sys.argv) < 6:
+    sys.exit(
+        'patch_signing.py: expected 5 profile UUIDs '
+        '(main, widgets, watch, watch_widgets, nse), got '
+        f'{len(sys.argv) - 1}'
+    )
 
 config_profiles = {
     'BC000004': sys.argv[1],   # DailyOK (main app)
     'BC000010': sys.argv[2],   # DailyOKWidgets
     'BC000012': sys.argv[3],   # DailyOKWatch
     'BC000014': sys.argv[4],   # DailyOKWatchWidgets
+    'BC000016': sys.argv[5],   # DailyOKNotificationService
 }
+
+# A blank UUID would silently inject PROVISIONING_PROFILE_SPECIFIER = "" and
+# fail deep inside xcodebuild.  Fail here with a clear pointer instead.
+for config_id, uuid in config_profiles.items():
+    if not uuid.strip():
+        sys.exit(
+            f'patch_signing.py: empty provisioning profile UUID for {config_id}. '
+            'A matching PROVISIONING_PROFILE_*_BASE64 secret is missing or '
+            'decoded to an invalid profile.'
+        )
 
 with open('DailyOK.xcodeproj/project.pbxproj', 'r') as f:
     lines = f.readlines()

--- a/.github/workflows/ios-build-deploy.yml
+++ b/.github/workflows/ios-build-deploy.yml
@@ -109,6 +109,21 @@ jobs:
           NSE_UUID=$(extract_uuid $RUNNER_TEMP/pp_nse.mobileprovision)
           echo "Profile UUIDs: main=$MAIN_UUID widgets=$WIDGETS_UUID watch=$WATCH_UUID watchwidgets=$WATCH_WIDGETS_UUID nse=$NSE_UUID"
 
+          # Fail fast with an actionable message if any profile failed to decode.
+          # An empty UUID means the matching PROVISIONING_PROFILE_*_BASE64 secret
+          # is missing or decoded to an invalid profile; without it the archive
+          # dies deep inside xcodebuild ("No profiles ... were found").
+          missing=""
+          [ -z "$MAIN_UUID" ]          && missing="$missing PROVISIONING_PROFILE_BASE64"
+          [ -z "$WIDGETS_UUID" ]       && missing="$missing PROVISIONING_PROFILE_WIDGETS_BASE64"
+          [ -z "$WATCH_UUID" ]         && missing="$missing PROVISIONING_PROFILE_WATCH_BASE64"
+          [ -z "$WATCH_WIDGETS_UUID" ] && missing="$missing PROVISIONING_PROFILE_WATCH_WIDGETS_BASE64"
+          [ -z "$NSE_UUID" ]           && missing="$missing PROVISIONING_PROFILE_NSE_BASE64"
+          if [ -n "$missing" ]; then
+            echo "::error::Missing/invalid provisioning profile secret(s):$missing. Add them to Infisical (prod/dailyok) as base64-encoded .mobileprovision files."
+            exit 1
+          fi
+
           echo "MAIN_PROFILE_UUID=$MAIN_UUID"                   >> $GITHUB_ENV
           echo "WIDGETS_PROFILE_UUID=$WIDGETS_UUID"             >> $GITHUB_ENV
           echo "WATCH_PROFILE_UUID=$WATCH_UUID"                 >> $GITHUB_ENV
@@ -116,7 +131,7 @@ jobs:
           echo "NSE_PROFILE_UUID=$NSE_UUID"                     >> $GITHUB_ENV
 
           python3 ../.github/scripts/patch_signing.py \
-            "$MAIN_UUID" "$WIDGETS_UUID" "$WATCH_UUID" "$WATCH_WIDGETS_UUID"
+            "$MAIN_UUID" "$WIDGETS_UUID" "$WATCH_UUID" "$WATCH_WIDGETS_UUID" "$NSE_UUID"
 
       - name: Resolve Swift Package dependencies
         working-directory: ios
@@ -197,10 +212,11 @@ jobs:
           set -o pipefail
           # The patch step above wrote CODE_SIGN_STYLE=Manual, CODE_SIGN_IDENTITY=
           # "Apple Distribution", and PROVISIONING_PROFILE_SPECIFIER=<UUID> into the
-          # four app-target Release configs in project.pbxproj.  SPM package targets
-          # are not in that file, so they keep their own Automatic (Development) signing
-          # and are never affected by the Distribution identity.  No global signing
-          # overrides are needed here.
+          # five app-target Release configs in project.pbxproj (main app, widgets,
+          # watch, watch widgets, and the NotificationService extension).  SPM package
+          # targets are not in that file, so they keep their own Automatic (Development)
+          # signing and are never affected by the Distribution identity.  No global
+          # signing overrides are needed here.
           xcodebuild archive \
             -project DailyOK.xcodeproj \
             -scheme DailyOK \


### PR DESCRIPTION
…ning

When the Notification Service Extension was added as a real build target (US-IOS080), the CI signing wiring was only half-completed: the workflow decodes the NSE profile, exports NSE_PROFILE_UUID, and lists it in ExportOptions.plist, but patch_signing.py was never updated to flip the NSE Release config (BC000016) from Automatic to Manual signing. Because CI archives without -allowProvisioningUpdates, the archive failed with "No profiles for 'com.wellvo.ios.NotificationService' were found ... Automatic signing is disabled."

- patch_signing.py: patch the 5th app target (BC000016) with the NSE profile UUID; require 5 UUID args and reject a blank UUID with a clear message instead of silently injecting an empty specifier.
- ios-build-deploy.yml: pass NSE_UUID to patch_signing.py and fail fast (before archive) with an actionable message naming any missing/invalid PROVISIONING_PROFILE_*_BASE64 secret.

Note: PROVISIONING_PROFILE_NSE_BASE64 must exist in Infisical (prod/dailyok) as a base64-encoded .mobileprovision, or the fail-fast guard will flag it.


Claude-Session: https://claude.ai/code/session_0195w1om1D5yDTNx8vFyUNsN