### PR TITLE
iOS: add SharedAppGroup.swift to NotificationService extension target

### DIFF
--- a/ios/DailyOK.xcodeproj/project.pbxproj
+++ b/ios/DailyOK.xcodeproj/project.pbxproj
@@ -186,6 +186,7 @@
 		BEMB0003 /* DailyOKWatchWidgetsExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F6P00001; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		/* Notification Service Extension sources */
 		B7F00001 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7F00001; };
+		B7S00001 /* SharedAppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1S00001; };
 		B7S00009 /* CertificatePinning.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1S00009; };
 		B7R00004 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = F7F00004; };
 		/* Embed the notification service extension into the app */
@@ -1232,6 +1233,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B7F00001 /* NotificationService.swift in Sources */,
+				B7S00001 /* SharedAppGroup.swift in Sources */,
 				B7S00009 /* CertificatePinning.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
## Summary

Follow-up to #248 (the NSE manual-signing fix). With signing resolved, the iOS archive on `main` (run #157, commit `4159df6`) advanced to compilation and failed in the `DailyOKNotificationService` target:

```
cannot find 'SharedAppGroup' in scope
```

## Root cause

The extension target's Sources phase (`S7000001`) compiles `CertificatePinning.swift`, whose `pinnedHashes` getter reads `SharedAppGroup.defaults` for the remote pin-override. When the NSE was wired up as a real target (US-IOS080), `CertificatePinning.swift` was added to its Sources phase **without** its `SharedAppGroup.swift` dependency. Every other target that compiles `CertificatePinning` (main app, watch) also compiles `SharedAppGroup` — the NSE was the sole exception.

The other errors in that log (`.whitespaces` contextual base, the `kSecAttrKeyType… as String` switch patterns) are **cascade diagnostics** from the missing symbol making the whole file fail type-checking — that exact file and switch compile cleanly in the shipping main-app and watch targets, so they clear once `SharedAppGroup` resolves.

## Change

Add `SharedAppGroup.swift` (fileRef `F1S00001`, Foundation-only, self-contained — no new transitive dependencies) to the NSE Sources phase, mirroring how the watch-widgets target already references the same file.

- `ios/DailyOK.xcodeproj/project.pbxproj`: +1 `PBXBuildFile` (`B7S00001`), +1 entry in phase `S7000001`.

## Verification

The prior run confirmed the signing chain now resolves all five profiles (`NSE_PROFILE_UUID` populated) and the archive reaches compilation. This target-membership fix is the remaining gap before the NSE compiles. Full green is confirmed by the next `iOS Build & Deploy` run on `main` after merge (the workflow runs only on push to `main` / `workflow_dispatch`).

## Backward compatibility

No persistent-state, API, or schema surface touched — Xcode project membership only.


---
_Generated by [Claude Code](https://claude.ai/code/session_0195w1om1D5yDTNx8vFyUNsN)_