### PR TITLE
Send receiver invitations natively from the owner's iPhone

### DIFF
--- a/edge-functions/functions/invite-receiver/index.ts
+++ b/edge-functions/functions/invite-receiver/index.ts
@@ -1,5 +1,4 @@
 import { supabaseAdmin } from "../../shared/supabase.ts";
-import { sendSMS } from "../../shared/sms.ts";
 import type { AuthResult } from "../../shared/auth.ts";
 import { isValidUUID, isValidTime24H, isValidTimezone, truncateString, sanitizeDisplayName } from "../../shared/validation.ts";
 
@@ -142,18 +141,23 @@ async function createInvite(body: InviteRequest, auth: AuthResult): Promise<Resp
   // Generate deep link (kept as fallback for QR/link sharing)
   const inviteLink = `https://dailyok.net/invite?token=${inviteToken}`;
 
-  // Send SMS invite to receiver
-  // The receiver just needs to download the app and sign in with this phone number —
-  // auto-join will match them to this invite automatically.
+  // Invitation delivery is now a *native* send from the Owner's own device
+  // (iOS Messages composer). We deliberately DO NOT send this invite through
+  // Twilio: an invite goes to a person who has not opted into our A2P 10DLC
+  // campaign, so it can't ride the approved sender. The Twilio campaign is
+  // reserved for escalation alerts (a clean, single-purpose use case).
+  //
+  // The app auto-joins the receiver by matching the phone number they sign in
+  // with, so the record above is all the backend needs. Here we return a
+  // pre-composed message body (P2P — no STOP/HELP footer, since it comes from
+  // the Owner's personal number) that the app drops into the native composer.
   // The pairing code is included so they can set up on an iPad or other device.
   const safeName = sanitizeDisplayName(name);
-  const smsBody =
-    `${safeName}, your family wants to check in with you daily using Daily OK. ` +
-    `Download the app and sign in with this phone number to get started: ` +
-    `https://apps.apple.com/app/daily-ok/id6742044109\n\n` +
-    `Setting up on an iPad? Use this code: ${pairingCode}\n\n` +
-    `Reply STOP to opt out. Msg&data rates may apply.`;
-  const smsResult = await sendSMS(phone, smsBody);
+  const inviteMessage =
+    `Hi ${safeName}! I'd like to check in with you every day using Daily OK. ` +
+    `Download the app and sign in with this phone number and we'll be ` +
+    `connected automatically: https://apps.apple.com/app/daily-ok/id6742044109\n\n` +
+    `Setting up on an iPad? Use this code: ${pairingCode}`;
 
   return new Response(
     JSON.stringify({
@@ -161,7 +165,11 @@ async function createInvite(body: InviteRequest, auth: AuthResult): Promise<Resp
       invite_token: inviteToken,
       invite_link: inviteLink,
       pairing_code: pairingCode,
-      sms_sent: smsResult.success,
+      // The Owner's device delivers the invite natively; the server never sends
+      // it. Kept for response-shape compatibility with older clients.
+      sms_sent: false,
+      // Pre-composed body for the native Messages composer (additive field).
+      invite_message: inviteMessage,
     }),
     { headers: { "Content-Type": "application/json" } }
   );

--- a/ios/DailyOK.xcodeproj/project.pbxproj
+++ b/ios/DailyOK.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		B1F0001B /* StreakBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F0001B; };
 		B1F0001C /* ContactQuickActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F0001C; };
 		B1F0001D /* SegmentedCodeField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F0001D; };
+		B1F00030 /* InviteMessageComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F00030; };
 		/* Shared (App Intents / widget / watch hand-off) */
 		B1S00001 /* SharedAppGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1S00001; };
 		B1S00002 /* SharedCheckInState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1S00002; };
@@ -278,6 +279,7 @@
 		F1F0001B /* StreakBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreakBadge.swift; sourceTree = "<group>"; };
 		F1F0001C /* ContactQuickActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactQuickActions.swift; sourceTree = "<group>"; };
 		F1F0001D /* SegmentedCodeField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedCodeField.swift; sourceTree = "<group>"; };
+		F1F00030 /* InviteMessageComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InviteMessageComposer.swift; sourceTree = "<group>"; };
 		/* Shared (App Intents / widget / watch hand-off) */
 		F1S00001 /* SharedAppGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedAppGroup.swift; sourceTree = "<group>"; };
 		F1S00002 /* SharedCheckInState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedCheckInState.swift; sourceTree = "<group>"; };
@@ -774,6 +776,7 @@
 				F1F0001B /* StreakBadge.swift */,
 				F1F0001C /* ContactQuickActions.swift */,
 				F1F0001D /* SegmentedCodeField.swift */,
+				F1F00030 /* InviteMessageComposer.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1128,6 +1131,7 @@
 				B1F0001B /* StreakBadge.swift in Sources */,
 				B1F0001C /* ContactQuickActions.swift in Sources */,
 				B1F0001D /* SegmentedCodeField.swift in Sources */,
+				B1F00030 /* InviteMessageComposer.swift in Sources */,
 				B1S00001 /* SharedAppGroup.swift in Sources */,
 				B1S00002 /* SharedCheckInState.swift in Sources */,
 				B1S00003 /* SharedCheckInClient.swift in Sources */,

--- a/ios/DailyOK/Services/FamilyService.swift
+++ b/ios/DailyOK/Services/FamilyService.swift
@@ -131,8 +131,19 @@ actor FamilyService {
         return members
     }
 
-    func inviteReceiver(familyId: UUID, name: String, phone: String, checkinTime: String) async throws {
-        try await EdgeFunctionsClient.invoke(
+    /// Create a pending invite for a receiver and return everything the app
+    /// needs to deliver it *natively* from the owner's own device.
+    ///
+    /// The invitation is no longer sent server-side via Twilio: an invite goes
+    /// to someone who hasn't opted into our A2P 10DLC campaign, so it can't ride
+    /// the approved sender (Twilio won't approve it). Instead the backend just
+    /// records the invite (so phone-based auto-join works) and hands back a
+    /// pre-composed message the caller drops into the iOS Messages composer, so
+    /// the text comes from the owner's personal number. The Twilio campaign is
+    /// reserved for escalation alerts only.
+    @discardableResult
+    func inviteReceiver(familyId: UUID, name: String, phone: String, checkinTime: String) async throws -> InviteDetails {
+        let response: InviteResponse = try await EdgeFunctionsClient.invoke(
             "invite-receiver",
             body: [
                 "family_id": familyId.uuidString,
@@ -140,6 +151,21 @@ actor FamilyService {
                 "phone": phone,
                 "checkin_time": checkinTime,
             ]
+        )
+
+        // Prefer the server-composed body (keeps the copy in one place), but
+        // fall back to a locally-built message so an older backend that doesn't
+        // return `invite_message` still produces a sendable invite.
+        let message = response.inviteMessage ?? InviteDetails.fallbackMessage(
+            name: name,
+            pairingCode: response.pairingCode
+        )
+
+        return InviteDetails(
+            phone: phone,
+            message: message,
+            pairingCode: response.pairingCode,
+            inviteLink: response.inviteLink
         )
     }
 
@@ -185,6 +211,52 @@ actor FamilyService {
             role: data.role ?? "receiver",
             checkinTime: data.checkinTime
         )
+    }
+}
+
+/// Everything the UI needs to hand an invite to the native iOS Messages
+/// composer. `Identifiable` so views can drive a `.sheet(item:)` from it.
+struct InviteDetails: Identifiable {
+    let id = UUID()
+    /// Recipient phone number, as the owner typed it (the composer normalizes).
+    let phone: String
+    /// Pre-composed message body — App Store link + optional pairing code.
+    let message: String
+    let pairingCode: String?
+    let inviteLink: String?
+
+    /// Local fallback body used only when the backend doesn't return a
+    /// server-composed `invite_message` (older edge-functions build). Kept in
+    /// sync with the server copy in `invite-receiver`. No STOP/HELP footer — this
+    /// is a person-to-person message from the owner's own number, not A2P.
+    static func fallbackMessage(name: String, pairingCode: String?) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let greeting = trimmed.isEmpty ? "Hi!" : "Hi \(trimmed)!"
+        var body =
+            "\(greeting) I'd like to check in with you every day using Daily OK. " +
+            "Download the app and sign in with this phone number and we'll be " +
+            "connected automatically: https://apps.apple.com/app/daily-ok/id6742044109"
+        if let code = pairingCode, !code.isEmpty {
+            body += "\n\nSetting up on an iPad? Use this code: \(code)"
+        }
+        return body
+    }
+}
+
+/// Raw decode of the `invite-receiver` response.
+struct InviteResponse: Decodable {
+    let success: Bool?
+    let inviteToken: String?
+    let inviteLink: String?
+    let pairingCode: String?
+    let inviteMessage: String?
+
+    enum CodingKeys: String, CodingKey {
+        case success
+        case inviteToken = "invite_token"
+        case inviteLink = "invite_link"
+        case pairingCode = "pairing_code"
+        case inviteMessage = "invite_message"
     }
 }
 

--- a/ios/DailyOK/ViewModels/OnboardingViewModel.swift
+++ b/ios/DailyOK/ViewModels/OnboardingViewModel.swift
@@ -30,6 +30,10 @@ final class OnboardingViewModel: ObservableObject {
     /// Drives the inline recovery UI (Open Settings / Continue anyway) instead of
     /// silently walking the user into the "All set" screen with a broken core feature.
     @Published var notificationDenied = false
+    /// Set once the invite record is created; drives the native Messages composer
+    /// so the invite is sent from the owner's own number (not our Twilio A2P
+    /// number). The step only advances after the composer reports a real send.
+    @Published var pendingInvite: InviteDetails?
 
     var createdFamily: Family?
 
@@ -102,18 +106,32 @@ final class OnboardingViewModel: ObservableObject {
         let timeString = formatter.string(from: checkinTime)
 
         do {
-            try await FamilyService.shared.inviteReceiver(
+            // Create the invite record, then hand the composed message to the
+            // native Messages composer instead of advancing immediately — the
+            // owner sends it from their own number.
+            pendingInvite = try await FamilyService.shared.inviteReceiver(
                 familyId: family.id,
                 name: receiverName,
                 phone: receiverPhone,
                 checkinTime: timeString
             )
-            advance()
         } catch {
             errorMessage = error.localizedDescription
         }
 
         isLoading = false
+    }
+
+    /// Called when the native invite composer closes. Advance only on a real
+    /// send; otherwise keep the owner on the form so they can try again (the
+    /// invite record already exists, so a resend just re-composes the text).
+    func handleInviteComposerFinish(sent: Bool) {
+        if sent {
+            errorMessage = nil
+            advance()
+        } else {
+            errorMessage = String(localized: "Message not sent. Tap Send Invite to try again.")
+        }
     }
 
     func requestNotificationPermission() async {

--- a/ios/DailyOK/Views/Components/InviteMessageComposer.swift
+++ b/ios/DailyOK/Views/Components/InviteMessageComposer.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+import MessageUI
+
+/// Presents the native iOS Messages composer, prefilled with an invite, so the
+/// text is sent from the **owner's own phone number** rather than our Twilio
+/// A2P number. An invite goes to someone who hasn't opted into our A2P 10DLC
+/// campaign, so it can't be delivered by the approved sender; sending it P2P
+/// from the owner's device sidesteps A2P entirely. The Twilio campaign is
+/// reserved for escalation alerts.
+///
+/// The invite record is created on the backend *before* this is presented, so
+/// phone-based auto-join works whenever the receiver eventually signs in — this
+/// controller is only the delivery step.
+struct InviteMessageComposer: UIViewControllerRepresentable {
+    let invite: InviteDetails
+    /// Called when the composer finishes. `sent` is true only when the user
+    /// actually sent the message (not on cancel or failure).
+    let onFinish: (_ sent: Bool) -> Void
+
+    /// Whether this device can send SMS/iMessage at all (false on most iPads,
+    /// the Simulator, and iPod touch). Callers fall back to the share sheet.
+    static var canSendText: Bool { MFMessageComposeViewController.canSendText() }
+
+    func makeUIViewController(context: Context) -> MFMessageComposeViewController {
+        let controller = MFMessageComposeViewController()
+        controller.messageComposeDelegate = context.coordinator
+        controller.recipients = [invite.phone]
+        controller.body = invite.message
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: MFMessageComposeViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(onFinish: onFinish) }
+
+    final class Coordinator: NSObject, MFMessageComposeViewControllerDelegate {
+        let onFinish: (Bool) -> Void
+
+        init(onFinish: @escaping (Bool) -> Void) { self.onFinish = onFinish }
+
+        func messageComposeViewController(
+            _ controller: MFMessageComposeViewController,
+            didFinishWith result: MessageComposeResult
+        ) {
+            // Let the parent clear its `.sheet(item:)` binding to dismiss; don't
+            // dismiss here or the two paths race.
+            onFinish(result == .sent)
+        }
+    }
+}
+
+/// Share-sheet fallback for devices that can't send SMS. Lets the owner deliver
+/// the invite text via any share target (Mail, WhatsApp, AirDrop, Copy, …).
+struct InviteShareSheet: UIViewControllerRepresentable {
+    let text: String
+    /// `completed` reflects the standard `UIActivityViewController` completion
+    /// (true when the user actually finished a share action).
+    let onFinish: (_ completed: Bool) -> Void
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let controller = UIActivityViewController(activityItems: [text], applicationActivities: nil)
+        controller.completionWithItemsHandler = { _, completed, _, _ in
+            context.coordinator.onFinish(completed)
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(onFinish: onFinish) }
+
+    final class Coordinator {
+        let onFinish: (Bool) -> Void
+        init(onFinish: @escaping (Bool) -> Void) { self.onFinish = onFinish }
+    }
+}
+
+extension View {
+    /// Present the native invite composer (or share-sheet fallback) for the
+    /// bound `InviteDetails`. Clears the binding on finish and reports whether
+    /// the invite was actually sent so the caller can advance its flow.
+    func inviteComposer(
+        item: Binding<InviteDetails?>,
+        onFinish: @escaping (_ sent: Bool) -> Void
+    ) -> some View {
+        modifier(InviteComposerModifier(item: item, onFinish: onFinish))
+    }
+}
+
+private struct InviteComposerModifier: ViewModifier {
+    @Binding var item: InviteDetails?
+    let onFinish: (Bool) -> Void
+
+    func body(content: Content) -> some View {
+        content.sheet(item: $item) { invite in
+            Group {
+                if InviteMessageComposer.canSendText {
+                    InviteMessageComposer(invite: invite) { sent in
+                        item = nil
+                        onFinish(sent)
+                    }
+                } else {
+                    InviteShareSheet(text: invite.message) { completed in
+                        item = nil
+                        onFinish(completed)
+                    }
+                }
+            }
+            .ignoresSafeArea()
+        }
+    }
+}

--- a/ios/DailyOK/Views/Onboarding/FirstReceiverWalkthroughView.swift
+++ b/ios/DailyOK/Views/Onboarding/FirstReceiverWalkthroughView.swift
@@ -14,6 +14,8 @@ struct FirstReceiverWalkthroughView: View {
     @State private var checkinTime = Self.defaultCheckinTime
     @State private var isLoading = false
     @State private var errorMessage: String?
+    /// Drives the native Messages composer once the invite record exists.
+    @State private var pendingInvite: InviteDetails?
     @FocusState private var focusedField: FormField?
 
     let onInviteSent: () async -> Void
@@ -46,6 +48,9 @@ struct FirstReceiverWalkthroughView: View {
                 .animation(DailyOKMotion.smoothSpring, value: currentStep)
 
                 footer
+            }
+            .inviteComposer(item: $pendingInvite) { sent in
+                handleInviteComposerFinish(sent: sent)
             }
             .background(AmbientBackground(tone: .calm))
             .navigationTitle(currentStep == .inviteSent ? "All Set" : "Add Your First Member")
@@ -205,7 +210,7 @@ struct FirstReceiverWalkthroughView: View {
                     Text("Invite sent to \(name)!")
                         .font(.title3.weight(.bold))
                         .multilineTextAlignment(.center)
-                    Text("They'll get a text at \(phone) with a link to download Daily OK.")
+                    Text("Your text to \(phone) is on its way with a link to download Daily OK.")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
@@ -218,7 +223,7 @@ struct FirstReceiverWalkthroughView: View {
                 Text("What \(displayName) does next:")
                     .font(.headline)
 
-                ReceiverFlowRow(number: 1, icon: "message.fill", text: "Opens the text message you triggered.")
+                ReceiverFlowRow(number: 1, icon: "message.fill", text: "Opens the text message you sent them.")
                 ReceiverFlowRow(number: 2, icon: "arrow.down.app.fill", text: "Taps the link to download Daily OK.")
                 ReceiverFlowRow(number: 3, icon: "phone.fill", text: "Signs in with the same phone number — no codes to type.")
                 ReceiverFlowRow(number: 4, icon: "bell.badge.fill", text: "Allows notifications so they get the daily reminder.")
@@ -379,7 +384,10 @@ struct FirstReceiverWalkthroughView: View {
             formatter.locale = Locale(identifier: "en_US_POSIX")
             formatter.dateFormat = "HH:mm"
 
-            try await FamilyService.shared.inviteReceiver(
+            // Create the invite record, then present the native composer so the
+            // owner sends the text from their own number. Advance to the success
+            // step only after the composer reports a real send.
+            let invite = try await FamilyService.shared.inviteReceiver(
                 familyId: family.id,
                 name: name.trimmingCharacters(in: .whitespaces),
                 phone: phone.trimmingCharacters(in: .whitespaces),
@@ -387,13 +395,24 @@ struct FirstReceiverWalkthroughView: View {
             )
 
             await onInviteSent()
-            DailyOKHaptics.success()
-            withAnimation(DailyOKMotion.smoothSpring) {
-                currentStep = .inviteSent
-            }
+            pendingInvite = invite
         } catch {
             DailyOKHaptics.error()
             errorMessage = DailyOKError.network(error).localizedDescription
+        }
+    }
+
+    /// Called when the native invite composer closes. Advance to the "invite
+    /// sent" step only on a real send; otherwise keep the owner on the form.
+    private func handleInviteComposerFinish(sent: Bool) {
+        guard sent else {
+            errorMessage = String(localized: "Message not sent. Tap Send Invite to try again.")
+            return
+        }
+        errorMessage = nil
+        DailyOKHaptics.success()
+        withAnimation(DailyOKMotion.smoothSpring) {
+            currentStep = .inviteSent
         }
     }
 

--- a/ios/DailyOK/Views/Onboarding/OnboardingView.swift
+++ b/ios/DailyOK/Views/Onboarding/OnboardingView.swift
@@ -287,6 +287,9 @@ struct OnboardingView: View {
         .padding(24)
         .glassCard(style: .thin, radius: DailyOKGlass.radiusLarge, elevation: DailyOKElevation.level3)
         .padding()
+        .inviteComposer(item: $viewModel.pendingInvite) { sent in
+            viewModel.handleInviteComposerFinish(sent: sent)
+        }
     }
 
     private var notificationsStep: some View {

--- a/ios/DailyOK/Views/Owner/FamilyView.swift
+++ b/ios/DailyOK/Views/Owner/FamilyView.swift
@@ -17,6 +17,10 @@ struct FamilyView: View {
     @State private var resendingMemberId: UUID?
     /// Transient success toast after a re-send.
     @State private var resendToast: String?
+    /// Invite record re-created for a resend; drives the native Messages composer.
+    @State private var pendingResendInvite: InviteDetails?
+    /// Display name of the member being re-invited, for the post-send toast.
+    @State private var resendTargetName: String?
 
     /// Receivers currently occupying a slot (active or pending invite). Excludes
     /// deactivated receivers so a removed member doesn't silently push the owner
@@ -188,6 +192,9 @@ struct FamilyView: View {
                 InviteReceiverSheet { await loadData() }
                     .dailyokGlassSheet(style: .regular)
             }
+            .inviteComposer(item: $pendingResendInvite) { sent in
+                handleResendComposerFinish(sent: sent)
+            }
             .sheet(isPresented: $showPaywall) {
                 // Wrap in a NavigationStack so the paywall has a title bar and an
                 // explicit Done button (App Review expects a dismissible paywall).
@@ -257,21 +264,34 @@ struct FamilyView: View {
         // silently resetting it to a hardcoded 08:00 on every re-send.
         let checkinTime = await currentCheckinTime(for: member)
         do {
-            try await FamilyService.shared.inviteReceiver(
+            // Re-create the invite record, then present the native composer so
+            // the owner re-sends the text from their own number.
+            let invite = try await FamilyService.shared.inviteReceiver(
                 familyId: family.id,
                 name: member.user?.displayName ?? "Family Member",
                 phone: member.user?.phone ?? "",
                 checkinTime: checkinTime
             )
-            DailyOKHaptics.success()
-            let name = member.user?.displayName ?? "them"
-            UIAccessibility.post(notification: .announcement, argument: String(localized: "Invite re-sent to \(name)"))
-            withAnimation { resendToast = "Invite re-sent to \(name)" }
-            try? await Task.sleep(nanoseconds: 2_500_000_000)
-            withAnimation { resendToast = nil }
+            resendTargetName = member.user?.displayName ?? "them"
+            pendingResendInvite = invite
         } catch {
             DailyOKHaptics.error()
             errorMessage = DailyOKError.network(error).localizedDescription
+        }
+    }
+
+    /// Called when the resend composer closes. Surface the success toast only on
+    /// a real send.
+    private func handleResendComposerFinish(sent: Bool) {
+        let name = resendTargetName ?? "them"
+        resendTargetName = nil
+        guard sent else { return }
+        DailyOKHaptics.success()
+        UIAccessibility.post(notification: .announcement, argument: String(localized: "Invite re-sent to \(name)"))
+        withAnimation { resendToast = "Invite re-sent to \(name)" }
+        Task {
+            try? await Task.sleep(nanoseconds: 2_500_000_000)
+            withAnimation { resendToast = nil }
         }
     }
 
@@ -433,6 +453,8 @@ struct InviteReceiverSheet: View {
     @State private var errorMessage: String?
     @State private var inviteSent = false
     @State private var showSetupGuide = false
+    /// Drives the native Messages composer once the invite record exists.
+    @State private var pendingInvite: InviteDetails?
     @FocusState private var focusedField: Field?
 
     private enum Field { case name, phone }
@@ -461,7 +483,7 @@ struct InviteReceiverSheet: View {
                                 .foregroundStyle(.green)
 
                             InstructionRow(number: 1, text: "Enter their name and phone number below")
-                            InstructionRow(number: 2, text: "They'll receive a text with an App Store link")
+                            InstructionRow(number: 2, text: "Your Messages app opens with a ready-to-send text — you tap send")
                             InstructionRow(number: 3, text: "They download the app and sign in with that same phone number")
                             InstructionRow(number: 4, text: "The app automatically connects them — no codes needed")
                         }
@@ -494,7 +516,7 @@ struct InviteReceiverSheet: View {
                     }
 
                     Section {
-                        Text("By tapping Send Invite, you confirm you have this person's consent to receive a one-time SMS from Daily OK with a link to download the app. Msg & data rates may apply. They can reply STOP to opt out or HELP for assistance. See our Privacy Policy (dailyok.net/privacy) and Terms of Use (dailyok.net/terms).")
+                        Text("Tapping Send Invite opens your Messages app with a prewritten text to this person — it's sent from your own phone number, and you choose whether to send it. Standard message rates may apply. See our Privacy Policy (dailyok.net/privacy) and Terms of Use (dailyok.net/terms).")
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -517,7 +539,7 @@ struct InviteReceiverSheet: View {
                             Text("Invite Sent to \(name)!")
                                 .font(.headline)
 
-                            Text("A text message has been sent to \(phone) with instructions to download and set up the app.")
+                            Text("Your text to \(phone) is on its way with instructions to download and set up the app.")
                                 .font(.subheadline)
                                 .foregroundStyle(.secondary)
                                 .multilineTextAlignment(.center)
@@ -574,6 +596,14 @@ struct InviteReceiverSheet: View {
                 ReceiverSetupGuideView(receiverName: name)
                     .dailyokGlassSheet(style: .thick)
             }
+            .inviteComposer(item: $pendingInvite) { sent in
+                if sent {
+                    errorMessage = nil
+                    inviteSent = true
+                } else {
+                    errorMessage = String(localized: "Message not sent. Tap Send Invite to try again.")
+                }
+            }
         }
     }
 
@@ -584,6 +614,7 @@ struct InviteReceiverSheet: View {
         }
 
         isLoading = true
+        errorMessage = nil
         // Wire format for the backend — POSIX-locked to keep the 24h "HH:mm"
         // contract stable across user locales (US-IOS044).
         let formatter = DateFormatter()
@@ -591,14 +622,17 @@ struct InviteReceiverSheet: View {
         formatter.dateFormat = "HH:mm"
 
         do {
-            try await FamilyService.shared.inviteReceiver(
+            // Create the invite record, then present the native composer so the
+            // owner sends the text from their own number. The success state is
+            // shown only after the composer reports a real send.
+            let invite = try await FamilyService.shared.inviteReceiver(
                 familyId: family.id,
                 name: name,
                 phone: phone,
                 checkinTime: formatter.string(from: checkinTime)
             )
             await onComplete()
-            inviteSent = true
+            pendingInvite = invite
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/website/src/pages/ChildSafety.tsx
+++ b/website/src/pages/ChildSafety.tsx
@@ -221,7 +221,7 @@ export default function ChildSafety() {
               <div className="cs-step-num">1</div>
               <div className="cs-step-icon"><Users size={28} /></div>
               <h3>Set up your family</h3>
-              <p>Create your account and invite your children via SMS or QR code. Set each child's check-in time based on their schedule.</p>
+              <p>Create your account and invite your children with a quick text from your own phone. Set each child's check-in time based on their schedule.</p>
             </div>
             <div className="cs-step">
               <div className="cs-step-num">2</div>

--- a/website/src/pages/Home.tsx
+++ b/website/src/pages/Home.tsx
@@ -200,8 +200,8 @@ export default function Home() {
               </div>
               <h3>Family Management</h3>
               <p>
-                Invite family members via SMS or QR code. Assign roles —
-                Receivers check in, Viewers monitor dashboards.
+                Invite family members with a quick text from your phone. Assign
+                roles — Receivers check in, Viewers monitor dashboards.
               </p>
             </div>
 

--- a/website/src/pages/Privacy.tsx
+++ b/website/src/pages/Privacy.tsx
@@ -125,21 +125,26 @@ export default function Privacy() {
           <section id="sms">
             <h2>SMS Messaging (A2P 10DLC)</h2>
             <p>
-              Daily OK uses SMS for two purposes only. We do not use phone numbers
-              for marketing. Mobile opt-in data, phone numbers, and SMS consent
+              Daily OK sends only one type of SMS message from its own systems:
+              escalation alerts (described below). We do not use phone numbers for
+              marketing. Mobile opt-in data, phone numbers, and SMS consent
               information will never be shared with or sold to any third party
               for any purpose.
             </p>
             <h3>Message types and consent</h3>
             <ul>
               <li>
-                <strong>Invitation message (one-time):</strong> When a family Owner
-                adds a family member as a Receiver inside the Daily OK app, the
-                Owner provides that person's phone number and confirms they have
-                permission to invite them. The Receiver then receives a single SMS
-                with a link to download the app. By providing the phone number and
-                accepting the invitation, the Receiver consents to receive this
-                one-time message.
+                <strong>Invitation message (sent from the Owner's own phone):</strong>{' '}
+                When a family Owner adds a family member as a Receiver inside the
+                Daily OK app, the Owner enters that person's phone number and the
+                app opens the Owner's native Messages app with a prewritten text
+                containing a link to download Daily OK. The Owner chooses whether to
+                send it, and the message is delivered from the Owner's own phone
+                number using their carrier — not from Daily OK. Daily OK does not
+                send this invitation and does not transmit it through our SMS
+                provider. We store the entered phone number so the invited person is
+                automatically connected to the family group when they sign in with
+                that number.
               </li>
               <li>
                 <strong>Escalation alerts:</strong> SMS escalation is OFF by
@@ -152,16 +157,20 @@ export default function Privacy() {
             </ul>
             <h3>Message frequency</h3>
             <p>
-              Invitation messages are sent once per invited Receiver. Escalation
-              alert frequency depends on missed check-ins; under normal conditions
-              users receive zero SMS messages on most days.
+              Daily OK does not send invitation messages; those are sent by the
+              Owner from their own device. Escalation alert frequency depends on
+              missed check-ins; under normal conditions users receive zero SMS
+              messages from Daily OK on most days.
             </p>
             <h3>Opt-out and help</h3>
             <p>
-              You may opt out at any time by replying <strong>STOP</strong> to any
-              message, or by disabling SMS escalation in the app's settings.
-              Reply <strong>HELP</strong> for assistance, or contact{' '}
+              You may opt out of escalation alerts at any time by replying{' '}
+              <strong>STOP</strong> to any alert message, or by disabling SMS
+              escalation in the app's settings. Reply <strong>HELP</strong> for
+              assistance, or contact{' '}
               <a href="mailto:support@dailyok.net">support@dailyok.net</a>.
+              Invitation texts come from an Owner's personal phone, so to stop
+              receiving those, reply to that person directly.
             </p>
             <h3>Carrier and rates</h3>
             <p>

--- a/website/src/pages/Support.tsx
+++ b/website/src/pages/Support.tsx
@@ -8,7 +8,7 @@ import './Support.css'
 const faqs = [
   {
     q: 'How do I set up Daily OK for my family?',
-    a: 'Download Daily OK from the App Store, create an account, and set up your family group. Then invite your loved ones via SMS or QR code — they\'ll receive a link to join automatically.',
+    a: 'Download Daily OK from the App Store, create an account, and set up your family group. Then invite your loved ones by sending them a text — the app opens your Messages app with a prewritten invite you send from your own phone. When they download the app and sign in with that number, they\'re connected automatically.',
   },
   {
     q: 'What happens if my loved one misses a check-in?',
@@ -28,7 +28,7 @@ const faqs = [
   },
   {
     q: 'How do I add more family members?',
-    a: 'From your Owner dashboard, tap "Add Member" and choose to invite via SMS link or QR code. If you need more members than your plan allows, you can purchase add-on slots.',
+    a: 'From your Owner dashboard, tap "Invite Family Member" and enter their name and phone number. The app opens your Messages app with a ready-to-send invite text that goes from your own phone. If you need more members than your plan allows, you can purchase add-on slots.',
   },
   {
     q: 'What are Critical Alerts?',


### PR DESCRIPTION
Twilio won't approve the A2P 10DLC campaign for invitation messages
because the recipient hasn't opted in. Move invite delivery to the
native iOS Messages composer so the text comes from the owner's own
phone number, and reserve the Twilio campaign for escalation alerts
only (a clean, single-purpose use case).

- invite-receiver edge function: stop sending the invite via Twilio.
  It still records the invite (so phone-based auto-join works) and now
  returns a pre-composed, P2P-style message body (no STOP/HELP footer)
  for the app to drop into the composer. Response shape stays backward
  compatible (sms_sent kept, invite_message added).
- iOS: FamilyService.inviteReceiver returns InviteDetails; new reusable
  InviteMessageComposer (MFMessageComposeViewController with a share-
  sheet fallback for devices that can't send SMS). All four invite
  flows (onboarding, first-receiver walkthrough, Family tab invite,
  resend) create the record then present the composer, advancing only
  on a real send.
- Copy: reword in-app and website (Privacy, Support, Home, ChildSafety)
  to reflect that the owner sends the invite from their own phone; the
  Privacy SMS section now scopes A2P/Twilio to escalation alerts only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LaWCpJdQ7zXG1vPjMWkBCG