### PR TITLE
Compliance audit: fix WCAG AA gaps and document GDPR/privacy findings

### DIFF
--- a/docs/COMPLIANCE_AUDIT.md
+++ b/docs/COMPLIANCE_AUDIT.md
@@ -16,13 +16,13 @@ However, the audit found **one critical legal contradiction** and **two material
 
 | # | Issue | Area | Severity | Status |
 |---|-------|------|----------|--------|
-| A | **Google Analytics (GA4) loads on every page with no consent banner**, directly contradicting the Privacy Policy & Cookie Notice ("no tracking cookies", "Cloudflare only", "no consent prompt required") | GDPR / ePrivacy / FTC | 🔴 Critical | **Needs decision** (§6.1) |
-| B | **Account deletion never deletes the `auth.users` identity row** — email, phone, password hash, and OAuth identities survive "deletion" | GDPR Art. 17 / CCPA | 🔴 Critical | **Documented, fix proposed** (§5.1) |
-| C | **Data export omits location history, care notes, and wellness signals** | GDPR Art. 15/20 | 🟠 Serious | **Documented, fix proposed** (§5.2) |
-| D | Primary-button and link **color contrast failed WCAG AA** site-wide (2.1:1 / 3.1:1) | ADA / WCAG 1.4.3 | 🔴→✅ | **Fixed in this branch** (§4) |
+| A | **Google Analytics (GA4) loaded on every page with no consent banner**, contradicting the Privacy Policy & Cookie Notice | GDPR / ePrivacy / FTC | 🔴→✅ | **Fixed:** GA now opt-in behind a consent banner (§6.1) |
+| B | **Account deletion never deleted the `auth.users` identity row** — email, phone, password hash, and OAuth identities survived "deletion" | GDPR Art. 17 / CCPA | 🔴→✅ | **Fixed:** migration `00049` (§5.1) |
+| C | **Data export omitted location history, care notes, and wellness signals** | GDPR Art. 15/20 | 🟠→✅ | **Fixed:** migration `00049` (§5.2) |
+| D | Primary-button and link **color contrast failed WCAG AA** site-wide (2.1:1 / 3.1:1) | ADA / WCAG 1.4.3 | 🔴→✅ | **Fixed** (§4) |
 | E | **Placeholder business address** (`1234 Example Street`) in Privacy, Terms, DMCA, and footer | GDPR Art. 13 / CCPA | 🟠 Serious | **Needs real data** (§6.2) |
-| F | Nested `<main>` landmarks, missing reduced-motion, SPA focus, heading skips | ADA / WCAG | 🟡→✅ | **Fixed in this branch** (§4) |
-| G | Undisclosed processors: Google Analytics, **Sentry** | GDPR Art. 13 transparency | 🟠 | Sentry **disclosed in this branch**; GA pending decision A |
+| F | Nested `<main>` landmarks, missing reduced-motion, SPA focus, heading skips | ADA / WCAG | 🟡→✅ | **Fixed** (§4) |
+| G | Undisclosed processors: Google Analytics, **Sentry** | GDPR Art. 13 transparency | 🟠→✅ | **Both now disclosed** in the Privacy Policy |
 | H | **No age gate / COPPA enforcement** despite Kid Mode and family targeting | COPPA | 🟠 | **Needs decision** (§6.3) |
 | I | No EU/UK **Article 27 representative** appointed | GDPR Art. 27 | 🟡 | **Needs decision** (§6.4) |
 
@@ -84,20 +84,20 @@ All of the documents a consumer app of this type is expected to publish **exist 
 
 ## 5. GDPR / CCPA — data-subject-rights mechanisms
 
-### 5.1 🔴 Account deletion does not delete the authentication identity (Right to Erasure)
+### 5.1 🔴→✅ Account deletion did not delete the authentication identity (Right to Erasure) — FIXED (`00049`)
 `delete_user_account()` (`supabase/migrations/00018_security_hardening.sql:139`) deletes from `push_tokens`, `checkins`, `notification_log`, `family_members`, owned `families`, and `public.users`. Child PII tables cascade correctly via `ON DELETE CASCADE`.
 
 **Defect:** the FK is `public.users.id → auth.users(id) ON DELETE CASCADE`, which cascades **auth → public**, *not* public → auth. The RPC only touches `public.users`, so the Supabase **Auth row survives**: email, phone number, bcrypt password hash, Google/Apple OAuth identities, and sign-in metadata persist indefinitely after a user "deletes" their account. This is the most material erasure defect (GDPR Art. 17 / CCPA §1798.105).
 
-**Proposed fix (new forward-only migration):** have `delete_user_account` also remove the auth identity — either `DELETE FROM auth.users WHERE id = p_user_id;` inside the `SECURITY DEFINER` function (which then cascades the public row away), or move deletion to an edge function that calls `supabaseAdmin.auth.admin.deleteUser()` (the admin client already exists — see `edge-functions/functions/auto-join/index.ts`). Signature is unchanged, so this is a safe `CREATE OR REPLACE`.
+**Fix applied:** migration `00049_gdpr_erasure_and_export_completeness.sql` adds `DELETE FROM auth.users WHERE id = p_user_id;` to the end of `delete_user_account` (`SECURITY DEFINER`, unchanged signature — backward-compatible `CREATE OR REPLACE`). Deleting the auth row also cascades away any residual `public.users` row. Runs with the migration/admin role's privileges on the `auth` schema.
 
-### 5.2 🟠 Data export is incomplete (Right to Access / Portability)
+### 5.2 🟠→✅ Data export was incomplete (Right to Access / Portability) — FIXED (`00049`)
 `export_user_data()` (`00010_gdpr_export_completeness.sql`, hardened in `00018`) returns profile, memberships, check-ins, requests, notification log, invite tokens (redacted), alerts, receiver settings, and push tokens. It was **never updated** for PII tables added later:
 - `location_updates` (00012) — location history
 - `care_notes` (00041) — free-text notes about receivers
 - `wellness_signals` (00042) — health-derived signals
 
-**Proposed fix:** extend the export RPC's JSON to include these three tables (additive, safe `CREATE OR REPLACE`).
+**Fix applied:** migration `00049` extends `export_user_data` with `location_updates` (subject's coordinates), `care_notes` (notes about or authored by the subject), and `wellness_signals` (the subject's activity signals). Additive JSON keys, backward-compatible `CREATE OR REPLACE`.
 
 ### 5.3 Consent management — 🟡 partial
 - **Location:** OS permission on-device + server gate `receiver_settings.location_tracking_enabled` (default `false`). Coordinates coarsened to ~110 m before upload (good minimization). *But* the enable toggle is owner-controlled, not held by the data subject being located, and there is **no stored consent record/timestamp**.
@@ -121,14 +121,16 @@ RLS enabled on all core + newer PII tables; `SECURITY DEFINER` functions re-chec
 
 ## 6. Items requiring a business / legal decision or real data
 
-### 6.1 🔴 Google Analytics vs. the "no-tracking" promise — **DECISION NEEDED**
-`pages/+onRenderHtml.tsx:23-29` unconditionally loads GA4 (`G-J2H67EW9JY`) on every page, and `_headers` whitelists the GA endpoints. GA4 sets `_ga`/`_gid` cookies and transfers data to Google (US). Meanwhile:
-- Cookie Notice: *"We do not use … behavioral-tracking cookies … no consent prompt is required."*
-- Privacy Policy: *"We do not use third-party advertising or tracking SDKs … our website uses Cloudflare Web Analytics."*
+### 6.1 🔴→✅ Google Analytics vs. the "no-tracking" promise — FIXED (consent-gated)
+Previously `pages/+onRenderHtml.tsx` unconditionally loaded GA4 (`G-J2H67EW9JY`) on every prerendered page while the Cookie Notice/Privacy Policy promised cookieless, no-consent analytics — an ePrivacy/GDPR prior-consent violation and a false published statement.
 
-This is both an **ePrivacy/GDPR prior-consent violation** (EU/UK) and a **false statement in a published policy** (FTC §5 / state UDAP exposure). Two clean resolutions:
-1. **Remove GA** and rely on the cookieless Cloudflare Web Analytics the policy already describes → statements become true, no banner needed. *(Recommended — matches the brand's privacy-first positioning; also note the Cloudflare beacon token is still the placeholder `YOUR_CF_ANALYTICS_TOKEN`.)*
-2. **Keep GA** → add a compliant consent banner (opt-in, GA blocked until consent, with reject-all) **and** rewrite the Cookie Notice + Privacy Policy to disclose GA and Google as a processor.
+**Fix applied (per the "keep GA, add consent" decision):**
+- GA removed from the prerendered `<head>`; it is now injected client-side **only after opt-in** via `src/lib/consent.ts` + `src/components/CookieConsent.tsx` (mounted in `Layout`).
+- Banner offers **Accept analytics / Decline**; choice persisted in `localStorage`. GA is not loaded until Accept, never after Decline, and never when the browser sends a **Global Privacy Control** signal (auto-declined). IP anonymization is enabled.
+- Prerender verified: 0 of 39 static HTML pages contain GA; the banner is client-only (not in SSR HTML).
+- Cookie Notice and Privacy Policy updated to disclose GA + Google LLC as a processor and describe the opt-in.
+
+**Remaining (deploy config, not code):** the Cloudflare Web Analytics beacon token in `+onRenderHtml.tsx` is still the placeholder `YOUR_CF_ANALYTICS_TOKEN` — set the real token so cookieless analytics actually reports.
 
 ### 6.2 🟠 Placeholder business address — **REAL DATA NEEDED**
 `1234 Example Street, Salt Lake City, UT 84101` appears in `Privacy.tsx`, `Terms.tsx`, `DMCA.tsx`, and `Footer.tsx` (each flagged *"update as required when finalized"*). GDPR Art. 13 and CCPA require the controller's real identity/contact; the DMCA agent address must be real to be effective. Provide the registered business address (and confirm the legal entity — pages say **Pearson Media LLC d/b/a Daily OK**).
@@ -143,21 +145,22 @@ The Privacy Policy states no EU/UK establishment and relies on SCCs. If EEA/UK r
 
 ## 7. Prioritized remediation roadmap
 
-**Do before claiming "fully compliant":**
-1. Resolve the **Google Analytics contradiction** (§6.1) — remove GA (recommended) or add consent + disclosure.
-2. Ship the **`auth.users` deletion** migration (§5.1).
-3. Ship the **export-completeness** migration (§5.2).
-4. Replace the **placeholder address** everywhere (§6.2).
+**Done in this branch:** ✅ GA consent-gating + disclosure (§6.1) · ✅ `auth.users` deletion migration (§5.1) · ✅ export-completeness migration (§5.2) · ✅ Sentry disclosure · ✅ all WCAG fixes (§4).
 
-**Next:**
-5. Decide **COPPA** posture and add enforcement/attestation (§6.3).
-6. Add an **in-app analytics opt-out** and a **consent-record** table (§5.3).
-7. Add **retention** for `care_notes` / battery / last-seen (§5.4).
-8. Appoint (or formally decline) an **Art. 27 representative** (§6.4).
-9. Reconcile the **CSP** (Sentry ingest host) and set the real **Cloudflare beacon token** (§5.5).
+**Still open — needs data / a decision (see §6):**
+1. Replace the **placeholder business address** everywhere (§6.2) — needs the real registered address.
+2. Decide **COPPA** posture and add enforcement/attestation (§6.3).
+3. Appoint (or formally decline) an **EU/UK Art. 27 representative** (§6.4).
+
+**Next (recommended follow-ups):**
+4. Add an **in-app analytics opt-out** and a **consent-record** table (§5.3).
+5. Add **retention** for `care_notes` / battery / last-seen (§5.4).
+6. Set the real **Cloudflare beacon token**; decide whether to allow the **Sentry ingest host** in CSP or remove the Sentry integration (§5.5, §6.1).
 
 **Ongoing:**
-10. Device-level **mobile a11y verification** (§4.3) and an **automated a11y CI gate**.
+7. Device-level **mobile a11y verification** (§4.3) and an **automated a11y CI gate**.
+
+> ⚠️ **Migration release note (per `CLAUDE.md`):** `00049` is backward-compatible (both functions are `CREATE OR REPLACE` with unchanged signatures; export only *adds* JSON keys). It still must ride the normal `develop → release → main` path with production-environment approval and a pre-migration backup — it does not run from this feature branch.
 
 ---
 
@@ -165,10 +168,14 @@ The Privacy Policy states no EU/UK establishment and relies on SCCs. If EEA/UK r
 
 **Accessibility (website):** `src/index.css` (accessible green tokens for buttons/links, reduced-motion query, focus-target rule), `src/components/Footer.css` (contrast), `src/components/ErrorBoundary.tsx` (button color), `src/components/Layout.tsx` (focusable main), `src/components/Header.tsx` (`aria-controls`), `src/App.tsx` (`RouteFocusManager`), nested-`<main>`→`<div>` on `Privacy/Terms/Cookies/DMCA/Accessibility`, heading order on `Home/Pricing/Support` (+ CSS), `BlogPost.tsx` (image `alt`).
 
-**Legal accuracy:** `Privacy.tsx` (disclosed **Sentry** processor), `Accessibility.tsx` (scoped dark-mode claim to the app).
+**Google Analytics consent-gating:** new `src/lib/consent.ts` + `src/components/CookieConsent.tsx` (+ `.css`); GA removed from `pages/+onRenderHtml.tsx`; banner mounted in `Layout.tsx`.
+
+**Legal accuracy:** `Privacy.tsx` (disclosed **Sentry** + **Google Analytics** processors, GA consent language), `Cookies.tsx` (GA opt-in section, corrected "no consent" wording), `Accessibility.tsx` (scoped dark-mode claim to the app).
+
+**Backend GDPR:** `supabase/migrations/00049_gdpr_erasure_and_export_completeness.sql` (auth-identity erasure + export completeness).
 
 **Docs:** this report.
 
-**Verification:** `tsc -b` ✅, `vite build` ✅, targeted ESLint on changed files clean (pre-existing admin/BlogPost data-effect lint warnings are unrelated to these changes).
+**Verification:** `tsc -b` ✅, `vite build` ✅, `vike prerender` ✅ (39 pages, 0 with GA), targeted ESLint on changed files clean (pre-existing admin/BlogPost data-effect lint warnings are unrelated to these changes).
 
-*Not changed here (require the decisions/data in §6, or are backend migrations warranting the release process in `CLAUDE.md`): Google Analytics, placeholder address, the two GDPR migrations, COPPA enforcement, Art. 27.*
+*Not changed here (require the data/decisions in §6): placeholder business address, COPPA enforcement, Art. 27 representative.*

--- a/docs/COMPLIANCE_AUDIT.md
+++ b/docs/COMPLIANCE_AUDIT.md
@@ -1,0 +1,174 @@
+# Compliance Audit — Wellvo / Daily OK
+
+**Audit date:** 2026-07-23
+**Scope:** Required legal documents & pages, ADA/WCAG 2.1 AA accessibility, and GDPR + US state privacy law (CCPA/CPRA and equivalents), across the website (`website/`), edge functions (`edge-functions/`), Supabase schema (`supabase/migrations/`), and the iOS/Android apps.
+**Prepared on branch:** `claude/compliance-audit-docs-accessibility-ts5wp7`
+
+> This document records the state of compliance at audit time, the fixes applied in this branch, and the remaining items that require a business/legal decision or real data before they can be closed. Severity legend: 🔴 Critical · 🟠 Serious · 🟡 Moderate · 🟢 Minor / informational.
+
+---
+
+## 1. Executive summary
+
+The product is in **good overall shape**: a full set of legal pages exists, the privacy program is thoughtfully written (data minimization, no ad SDKs, SMS/A2P disclosures, US multi-state rights), and the core data-subject-rights plumbing (data export RPC, in-app account deletion on both platforms, retention cron jobs, thorough RLS) is largely built.
+
+However, the audit found **one critical legal contradiction** and **two material backend defects** that should be resolved before claiming "full compliance":
+
+| # | Issue | Area | Severity | Status |
+|---|-------|------|----------|--------|
+| A | **Google Analytics (GA4) loads on every page with no consent banner**, directly contradicting the Privacy Policy & Cookie Notice ("no tracking cookies", "Cloudflare only", "no consent prompt required") | GDPR / ePrivacy / FTC | 🔴 Critical | **Needs decision** (§6.1) |
+| B | **Account deletion never deletes the `auth.users` identity row** — email, phone, password hash, and OAuth identities survive "deletion" | GDPR Art. 17 / CCPA | 🔴 Critical | **Documented, fix proposed** (§5.1) |
+| C | **Data export omits location history, care notes, and wellness signals** | GDPR Art. 15/20 | 🟠 Serious | **Documented, fix proposed** (§5.2) |
+| D | Primary-button and link **color contrast failed WCAG AA** site-wide (2.1:1 / 3.1:1) | ADA / WCAG 1.4.3 | 🔴→✅ | **Fixed in this branch** (§4) |
+| E | **Placeholder business address** (`1234 Example Street`) in Privacy, Terms, DMCA, and footer | GDPR Art. 13 / CCPA | 🟠 Serious | **Needs real data** (§6.2) |
+| F | Nested `<main>` landmarks, missing reduced-motion, SPA focus, heading skips | ADA / WCAG | 🟡→✅ | **Fixed in this branch** (§4) |
+| G | Undisclosed processors: Google Analytics, **Sentry** | GDPR Art. 13 transparency | 🟠 | Sentry **disclosed in this branch**; GA pending decision A |
+| H | **No age gate / COPPA enforcement** despite Kid Mode and family targeting | COPPA | 🟠 | **Needs decision** (§6.3) |
+| I | No EU/UK **Article 27 representative** appointed | GDPR Art. 27 | 🟡 | **Needs decision** (§6.4) |
+
+---
+
+## 2. Required documents & pages — inventory
+
+All of the documents a consumer app of this type is expected to publish **exist and are routed** (`website/src/App.tsx`):
+
+| Document | Route | Present | Notes |
+|----------|-------|:-------:|-------|
+| Privacy Policy | `/privacy` | ✅ | Thorough; GDPR + CCPA/CPRA + 20-state disclosures, legal bases, retention, sub-processors, SMS/A2P. See gaps A, E, G. |
+| Terms of Use | `/terms` | ✅ | Arbitration + class-action waiver + opt-out, Apple EULA terms, subscription/auto-renew disclosures. See gap E. |
+| Cookie Notice | `/cookies` | ✅ | Claims cookieless analytics — **contradicted by GA** (gap A). |
+| Accessibility Statement | `/accessibility` | ✅ | Claims WCAG AA + reduced motion; brought into line with reality this branch. |
+| DMCA / Copyright Policy | `/dmca` | ✅ | §512 agent, counter-notice, repeat-infringer. See gap E. |
+| Support / Contact | `/support` | ✅ | Email + FAQ; account deletion & cancellation documented. |
+| Child & Teen Safety | `/child-safety` | ✅ | Policy text only; no technical age enforcement (gap H). |
+
+**Verdict:** No required document is *missing*. The gaps are in **accuracy** (GA contradiction, placeholder address, undisclosed processors) and **backing mechanisms** (deletion/export completeness), not in coverage.
+
+---
+
+## 3. Methodology
+
+- Manual read of every legal page, the layout/header/footer, the HTML shell generator (`pages/+onRenderHtml.tsx`), `_headers` (CSP/security), and global CSS.
+- Two parallel deep-dive audits:
+  - **Accessibility** — component-by-component WCAG 2.1 AA review of the marketing site.
+  - **Privacy/GDPR mechanisms** — traced deletion, export, consent, retention, processors, COPPA, and security across edge functions, migrations, and both mobile apps.
+- Contrast ratios computed against WCAG relative-luminance formula.
+
+---
+
+## 4. Accessibility (ADA / WCAG 2.1 AA)
+
+### 4.1 What was already correct
+`<html lang>` set · compliant viewport (zoomable, no `maximum-scale`) · skip link wired to `#main-content` · global `:focus-visible` ring · per-page `<title>`/meta · nav `aria-current`/`aria-label` · emoji decorations use `role="img"` + label · correct `<a>` vs `<button>` semantics · no public-facing forms (Support/Pricing use `mailto:` + native `<details>`), so labeling SC 3.3.2 does not apply.
+
+### 4.2 Findings and fixes applied in this branch
+
+| ID | SC | Issue | Fix |
+|----|----|-------|-----|
+| C1 🔴 | 1.4.3 | Primary button: white on `#2ECC71` ≈ **2.1:1** (every CTA site-wide) | Added `--green-accessible: #157F43` (**5.06:1** with white); applied to `.btn-primary`, `.btn-secondary`, and the `ErrorBoundary` button. |
+| S1 🟠 | 1.4.3 | Body links: `#22a85c` on white ≈ **3.1:1** | Global `a` color → `--green-accessible`. |
+| S2 🟠 | 1.3.1 / 4.1.2 | Nested/duplicate `<main>` (Layout's `<main>` + a second `<main>` in Privacy/Terms/Cookies/DMCA/Accessibility) | Inner `<main>` → `<div>` on all five legal pages. |
+| M1 🟡 | 2.4.3 | SPA route change didn't move focus or scroll | Added `RouteFocusManager` in `App.tsx` (scroll-to-top + focus `#main-content`, `tabIndex=-1`) on navigation. |
+| M2 🟡 | 2.3.3 | `prefers-reduced-motion` honored nowhere, contradicting the statement | Global reduced-motion media query in `index.css`. |
+| M3 🟡 | 1.3.1 / 2.4.10 | Heading skips (Pricing h1→h3, Support h1→h3, Home h2→h4) | Reordered headings + matching CSS selectors on Home/Pricing/Support. |
+| M4 🟡 | 1.4.3 | Footer secondary text ≈ 3.7:1; admin link dimmed to ~2:1 | `.footer-note`/`.footer-admin-link` → `--gray-400`; removed opacity. |
+| m1 🟢 | 4.1.2 | Menu toggle had no `aria-controls` | Added `id="primary-navigation"` + `aria-controls`. |
+| m2 🟢 | 1.1.1 | Blog hero `alt=""` on a meaningful image | `alt={post.title}`. |
+| m3 🟢 | — | Statement overstated site conformance (contrast, "dark mode" on web) | Scoped dark-mode claim to the app; other claims now true post-fix. |
+
+### 4.3 Remaining / recommended (not blocking)
+- **Mobile-app WCAG** (VoiceOver labels, Dynamic Type to 200%, Voice Control) is asserted in the statement but was **not independently verified** in this pass. Recommend a device pass with VoiceOver + largest Dynamic Type before renewing the claim.
+- Consider adding an automated a11y gate (axe-core in Vitest / Playwright) to CI to prevent regressions.
+
+---
+
+## 5. GDPR / CCPA — data-subject-rights mechanisms
+
+### 5.1 🔴 Account deletion does not delete the authentication identity (Right to Erasure)
+`delete_user_account()` (`supabase/migrations/00018_security_hardening.sql:139`) deletes from `push_tokens`, `checkins`, `notification_log`, `family_members`, owned `families`, and `public.users`. Child PII tables cascade correctly via `ON DELETE CASCADE`.
+
+**Defect:** the FK is `public.users.id → auth.users(id) ON DELETE CASCADE`, which cascades **auth → public**, *not* public → auth. The RPC only touches `public.users`, so the Supabase **Auth row survives**: email, phone number, bcrypt password hash, Google/Apple OAuth identities, and sign-in metadata persist indefinitely after a user "deletes" their account. This is the most material erasure defect (GDPR Art. 17 / CCPA §1798.105).
+
+**Proposed fix (new forward-only migration):** have `delete_user_account` also remove the auth identity — either `DELETE FROM auth.users WHERE id = p_user_id;` inside the `SECURITY DEFINER` function (which then cascades the public row away), or move deletion to an edge function that calls `supabaseAdmin.auth.admin.deleteUser()` (the admin client already exists — see `edge-functions/functions/auto-join/index.ts`). Signature is unchanged, so this is a safe `CREATE OR REPLACE`.
+
+### 5.2 🟠 Data export is incomplete (Right to Access / Portability)
+`export_user_data()` (`00010_gdpr_export_completeness.sql`, hardened in `00018`) returns profile, memberships, check-ins, requests, notification log, invite tokens (redacted), alerts, receiver settings, and push tokens. It was **never updated** for PII tables added later:
+- `location_updates` (00012) — location history
+- `care_notes` (00041) — free-text notes about receivers
+- `wellness_signals` (00042) — health-derived signals
+
+**Proposed fix:** extend the export RPC's JSON to include these three tables (additive, safe `CREATE OR REPLACE`).
+
+### 5.3 Consent management — 🟡 partial
+- **Location:** OS permission on-device + server gate `receiver_settings.location_tracking_enabled` (default `false`). Coordinates coarsened to ~110 m before upload (good minimization). *But* the enable toggle is owner-controlled, not held by the data subject being located, and there is **no stored consent record/timestamp**.
+- **Analytics:** iOS uses TelemetryDeck (anonymous, hashed) — but there is **no in-app analytics opt-out** and no consent capture.
+- **No consent-ledger / versioned ToS-&-Privacy acceptance** table anywhere in the schema.
+
+### 5.4 Retention & minimization — ✅ mostly present
+- `enforce_data_retention()` daily — check-ins per family `data_retention_days`, notification log > 90 days, expired invites (`00005`).
+- `cleanup_old_location_data()` daily — deletes `location_updates` > 7 days (`00012`). Strong minimization on the most sensitive data.
+- **Gap:** `care_notes` (free text) and `users.last_battery_level` / `last_seen_at` have **no purge** — they persist until account deletion.
+
+### 5.5 Third-party processors — identified vs. disclosed
+In use: Supabase, Contabo/Coolify, Cloudflare, TelemetryDeck, APNs, FCM, Twilio, Apple/Google billing, **Sentry**, **Google Analytics**.
+- **Sentry** — now added to the Privacy Policy sub-processor list in this branch.
+- **Google Analytics** — still undisclosed and, more importantly, contradicts the policy outright (§6.1). Also note the `_headers` CSP allows GA endpoints but **omits the Sentry ingest host** (`*.ingest.us.sentry.io`), so browser error reporting is currently blocked by CSP — worth reconciling.
+
+### 5.6 Security of processing — ✅ largely solid
+RLS enabled on all core + newer PII tables; `SECURITY DEFINER` functions re-check `auth.uid()`; strict CORS/JWT/webhook-secret auth + rate limiting on the edge server; iOS cert pinning; SMS "STOP"; token secrets redacted in export. Encryption-at-rest is deployment config (not in-repo) and could not be independently confirmed; care-note bodies and phone numbers are stored in plaintext columns.
+
+---
+
+## 6. Items requiring a business / legal decision or real data
+
+### 6.1 🔴 Google Analytics vs. the "no-tracking" promise — **DECISION NEEDED**
+`pages/+onRenderHtml.tsx:23-29` unconditionally loads GA4 (`G-J2H67EW9JY`) on every page, and `_headers` whitelists the GA endpoints. GA4 sets `_ga`/`_gid` cookies and transfers data to Google (US). Meanwhile:
+- Cookie Notice: *"We do not use … behavioral-tracking cookies … no consent prompt is required."*
+- Privacy Policy: *"We do not use third-party advertising or tracking SDKs … our website uses Cloudflare Web Analytics."*
+
+This is both an **ePrivacy/GDPR prior-consent violation** (EU/UK) and a **false statement in a published policy** (FTC §5 / state UDAP exposure). Two clean resolutions:
+1. **Remove GA** and rely on the cookieless Cloudflare Web Analytics the policy already describes → statements become true, no banner needed. *(Recommended — matches the brand's privacy-first positioning; also note the Cloudflare beacon token is still the placeholder `YOUR_CF_ANALYTICS_TOKEN`.)*
+2. **Keep GA** → add a compliant consent banner (opt-in, GA blocked until consent, with reject-all) **and** rewrite the Cookie Notice + Privacy Policy to disclose GA and Google as a processor.
+
+### 6.2 🟠 Placeholder business address — **REAL DATA NEEDED**
+`1234 Example Street, Salt Lake City, UT 84101` appears in `Privacy.tsx`, `Terms.tsx`, `DMCA.tsx`, and `Footer.tsx` (each flagged *"update as required when finalized"*). GDPR Art. 13 and CCPA require the controller's real identity/contact; the DMCA agent address must be real to be effective. Provide the registered business address (and confirm the legal entity — pages say **Pearson Media LLC d/b/a Daily OK**).
+
+### 6.3 🟠 COPPA / age gating — **DECISION NEEDED**
+No birthdate field, age gate, or age verification exists, yet **Kid Mode** (`00014`) implies under-18 (potentially under-13) receivers are onboarded by a parent, with optional location + free-text notes about them. Policies state "13+", but nothing enforces it. Decide: add an age gate / parental-consent capture, or formally restrict onboarding to 13+ with an attestation.
+
+### 6.4 🟡 EU/UK Article 27 representative — **DECISION NEEDED**
+The Privacy Policy states no EU/UK establishment and relies on SCCs. If EEA/UK residents are actually served, GDPR/UK-GDPR Art. 27 requires **appointing** a representative (naming them in the policy), not merely stating none exists. Either appoint one, or (if not targeting the EEA/UK) make that explicit and reconsider the EEA-facing language.
+
+---
+
+## 7. Prioritized remediation roadmap
+
+**Do before claiming "fully compliant":**
+1. Resolve the **Google Analytics contradiction** (§6.1) — remove GA (recommended) or add consent + disclosure.
+2. Ship the **`auth.users` deletion** migration (§5.1).
+3. Ship the **export-completeness** migration (§5.2).
+4. Replace the **placeholder address** everywhere (§6.2).
+
+**Next:**
+5. Decide **COPPA** posture and add enforcement/attestation (§6.3).
+6. Add an **in-app analytics opt-out** and a **consent-record** table (§5.3).
+7. Add **retention** for `care_notes` / battery / last-seen (§5.4).
+8. Appoint (or formally decline) an **Art. 27 representative** (§6.4).
+9. Reconcile the **CSP** (Sentry ingest host) and set the real **Cloudflare beacon token** (§5.5).
+
+**Ongoing:**
+10. Device-level **mobile a11y verification** (§4.3) and an **automated a11y CI gate**.
+
+---
+
+## 8. Changes applied in this branch
+
+**Accessibility (website):** `src/index.css` (accessible green tokens for buttons/links, reduced-motion query, focus-target rule), `src/components/Footer.css` (contrast), `src/components/ErrorBoundary.tsx` (button color), `src/components/Layout.tsx` (focusable main), `src/components/Header.tsx` (`aria-controls`), `src/App.tsx` (`RouteFocusManager`), nested-`<main>`→`<div>` on `Privacy/Terms/Cookies/DMCA/Accessibility`, heading order on `Home/Pricing/Support` (+ CSS), `BlogPost.tsx` (image `alt`).
+
+**Legal accuracy:** `Privacy.tsx` (disclosed **Sentry** processor), `Accessibility.tsx` (scoped dark-mode claim to the app).
+
+**Docs:** this report.
+
+**Verification:** `tsc -b` ✅, `vite build` ✅, targeted ESLint on changed files clean (pre-existing admin/BlogPost data-effect lint warnings are unrelated to these changes).
+
+*Not changed here (require the decisions/data in §6, or are backend migrations warranting the release process in `CLAUDE.md`): Google Analytics, placeholder address, the two GDPR migrations, COPPA enforcement, Art. 27.*

--- a/supabase/migrations/00049_gdpr_erasure_and_export_completeness.sql
+++ b/supabase/migrations/00049_gdpr_erasure_and_export_completeness.sql
@@ -1,0 +1,147 @@
+-- GDPR Erasure Completeness + Data Export Completeness
+-- Migration: 00049_gdpr_erasure_and_export_completeness
+--
+-- Two forward-only, backward-compatible fixes (both CREATE OR REPLACE with
+-- unchanged signatures; export gains keys clients already ignore-if-unknown):
+--
+--   1. delete_user_account: also delete the auth.users identity row. The FK
+--      public.users.id -> auth.users(id) cascades auth->public, NOT
+--      public->auth, so deleting only public.users left the Supabase Auth
+--      identity (email, phone, password hash, OAuth identities, sign-in
+--      metadata) behind — an incomplete Right to Erasure (GDPR Art. 17 /
+--      CCPA §1798.105). Deleting auth.users cascades the public row away too.
+--
+--   2. export_user_data: include location_updates (00012), care_notes (00041),
+--      and wellness_signals (00042), which were added after the export RPC and
+--      never wired in — an incomplete Right to Access / Portability
+--      (GDPR Art. 15/20).
+
+BEGIN;
+
+-- =============================================================================
+-- 1. ERASURE — delete the authentication identity as well
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION delete_user_account(p_user_id UUID)
+RETURNS BOOLEAN AS $$
+BEGIN
+    IF auth.uid() IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated';
+    END IF;
+    IF auth.uid() != p_user_id THEN
+        RAISE EXCEPTION 'Unauthorized';
+    END IF;
+
+    -- Explicit deletes for tables keyed off the public.users row.
+    DELETE FROM push_tokens WHERE user_id = p_user_id;
+    DELETE FROM checkins WHERE receiver_id = p_user_id;
+    DELETE FROM notification_log WHERE user_id = p_user_id;
+    DELETE FROM family_members WHERE user_id = p_user_id;
+    DELETE FROM families WHERE owner_id = p_user_id;
+    DELETE FROM users WHERE id = p_user_id;
+
+    -- Remove the Supabase Auth identity. This is the row the previous version
+    -- never touched; deleting it also cascades away any residual public.users
+    -- row (defense in depth). Requires the function to run with a role that
+    -- has DELETE on auth.users — guaranteed here because it is SECURITY
+    -- DEFINER and owned by the migration/admin role.
+    DELETE FROM auth.users WHERE id = p_user_id;
+
+    RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- =============================================================================
+-- 2. ACCESS / PORTABILITY — include location, care notes, and wellness signals
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION export_user_data(p_user_id UUID)
+RETURNS JSONB AS $$
+DECLARE
+    result JSONB;
+BEGIN
+    IF auth.uid() IS NULL THEN
+        RAISE EXCEPTION 'Not authenticated';
+    END IF;
+    IF auth.uid() != p_user_id THEN
+        RAISE EXCEPTION 'Unauthorized';
+    END IF;
+
+    SELECT jsonb_build_object(
+        'user', (SELECT row_to_json(u) FROM users u WHERE u.id = p_user_id),
+        'family_memberships', (
+            SELECT COALESCE(jsonb_agg(row_to_json(fm)), '[]'::jsonb)
+            FROM family_members fm WHERE fm.user_id = p_user_id
+        ),
+        'checkins', (
+            SELECT COALESCE(jsonb_agg(row_to_json(c)), '[]'::jsonb)
+            FROM checkins c WHERE c.receiver_id = p_user_id
+        ),
+        'checkin_requests', (
+            SELECT COALESCE(jsonb_agg(row_to_json(cr)), '[]'::jsonb)
+            FROM checkin_requests cr
+            WHERE cr.receiver_id = p_user_id OR cr.requested_by = p_user_id
+        ),
+        'notification_log', (
+            SELECT COALESCE(jsonb_agg(row_to_json(nl)), '[]'::jsonb)
+            FROM notification_log nl WHERE nl.user_id = p_user_id
+        ),
+        'invite_tokens', (
+            SELECT COALESCE(jsonb_agg(jsonb_build_object(
+                'id', it.id,
+                'family_id', it.family_id,
+                'token', '[REDACTED]',
+                'role', it.role,
+                'created_by', it.created_by,
+                'used_by', it.used_by,
+                'expires_at', it.expires_at,
+                'created_at', it.created_at
+            )), '[]'::jsonb)
+            FROM invite_tokens it WHERE it.created_by = p_user_id
+        ),
+        'alerts', (
+            SELECT COALESCE(jsonb_agg(row_to_json(a)), '[]'::jsonb)
+            FROM alerts a
+            JOIN families f ON f.id = a.family_id
+            WHERE f.owner_id = p_user_id
+        ),
+        'receiver_settings', (
+            SELECT COALESCE(jsonb_agg(row_to_json(rs)), '[]'::jsonb)
+            FROM receiver_settings rs
+            WHERE rs.family_member_id IN (
+                SELECT fm.id FROM family_members fm WHERE fm.user_id = p_user_id
+            )
+        ),
+        'push_tokens', (
+            SELECT COALESCE(jsonb_agg(jsonb_build_object(
+                'id', pt.id,
+                'platform', pt.platform,
+                'is_active', pt.is_active,
+                'created_at', pt.created_at
+            )), '[]'::jsonb)
+            FROM push_tokens pt WHERE pt.user_id = p_user_id
+        ),
+        -- Location history (the subject's own coordinates; ~110 m coarsened).
+        'location_updates', (
+            SELECT COALESCE(jsonb_agg(row_to_json(lu)), '[]'::jsonb)
+            FROM location_updates lu WHERE lu.receiver_id = p_user_id
+        ),
+        -- Care notes about the subject, and care notes the subject authored.
+        'care_notes', (
+            SELECT COALESCE(jsonb_agg(row_to_json(cn)), '[]'::jsonb)
+            FROM care_notes cn
+            WHERE cn.receiver_id = p_user_id OR cn.author_id = p_user_id
+        ),
+        -- Derived wellness signals (activity booleans, never raw health values).
+        'wellness_signals', (
+            SELECT COALESCE(jsonb_agg(row_to_json(ws)), '[]'::jsonb)
+            FROM wellness_signals ws WHERE ws.receiver_id = p_user_id
+        ),
+        'exported_at', NOW()
+    ) INTO result;
+
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMIT;

--- a/website/pages/+onRenderHtml.tsx
+++ b/website/pages/+onRenderHtml.tsx
@@ -20,13 +20,12 @@ interface HelmetContext {
 // from body → head after render by extractHeadTags().
 const STATIC_HEAD = `
     <meta charset="UTF-8" />
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-J2H67EW9JY"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'G-J2H67EW9JY');
-    </script>
+    <!--
+      Google Analytics is intentionally NOT loaded here. GA4 sets cookies and
+      requires prior opt-in consent under the EU ePrivacy Directive / GDPR, so
+      it is injected client-side only after the visitor accepts via the cookie
+      consent banner. See src/lib/consent.ts and src/components/CookieConsent.tsx.
+    -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icon-16.png" />

--- a/website/src/App.tsx
+++ b/website/src/App.tsx
@@ -1,7 +1,30 @@
-import { lazy, Suspense } from 'react'
-import { Routes, Route } from 'react-router-dom'
+import { lazy, Suspense, useEffect, useRef } from 'react'
+import { Routes, Route, useLocation } from 'react-router-dom'
 import Layout from './components/Layout'
 import { AdminAuthProvider } from './admin/AdminAuthProvider'
+
+/**
+ * On client-side navigation, scroll to top and move focus to the main
+ * landmark so keyboard and screen-reader users land on the new page instead
+ * of the now-unmounted link they clicked (WCAG 2.4.3 Focus Order). Skips the
+ * initial render so first paint / hydration doesn't steal focus.
+ */
+function RouteFocusManager() {
+  const { pathname } = useLocation()
+  const isFirstRender = useRef(true)
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false
+      return
+    }
+    window.scrollTo(0, 0)
+    const main = document.getElementById('main-content')
+    main?.focus()
+  }, [pathname])
+
+  return null
+}
 
 const Home = lazy(() => import('./pages/Home'))
 const Privacy = lazy(() => import('./pages/Privacy'))
@@ -55,6 +78,7 @@ function LoadingSpinner() {
 function App() {
   return (
     <AdminAuthProvider>
+      <RouteFocusManager />
       <Suspense fallback={<LoadingSpinner />}>
         <Routes>
           {/* Public marketing + blog */}

--- a/website/src/components/CookieConsent.css
+++ b/website/src/components/CookieConsent.css
@@ -1,0 +1,58 @@
+.cookie-consent {
+  position: fixed;
+  left: 16px;
+  right: 16px;
+  bottom: 16px;
+  z-index: 2000;
+  background: var(--white);
+  border: 1px solid var(--gray-200);
+  border-radius: 14px;
+  box-shadow: 0 8px 30px rgba(17, 24, 39, 0.18);
+  padding: 20px 24px;
+}
+
+.cookie-consent-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.cookie-consent-title {
+  font-weight: 700;
+  color: var(--gray-900);
+  margin-bottom: 4px;
+}
+
+.cookie-consent-text p {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--gray-700);
+  margin: 0;
+}
+
+.cookie-consent-actions {
+  display: flex;
+  gap: 12px;
+  flex-shrink: 0;
+}
+
+.cookie-consent-actions .btn {
+  white-space: nowrap;
+}
+
+@media (max-width: 768px) {
+  .cookie-consent-inner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .cookie-consent-actions {
+    justify-content: stretch;
+  }
+  .cookie-consent-actions .btn {
+    flex: 1;
+    justify-content: center;
+  }
+}

--- a/website/src/components/CookieConsent.tsx
+++ b/website/src/components/CookieConsent.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  getStoredConsent,
+  storeConsent,
+  loadGoogleAnalytics,
+  hasGlobalPrivacyControlOptOut,
+} from '../lib/consent'
+import './CookieConsent.css'
+
+/**
+ * Opt-in cookie-consent banner. Analytics (Google Analytics) stays unloaded
+ * until the visitor accepts. Renders nothing during SSR/prerender and until
+ * the client decides, so no banner is baked into the static HTML.
+ */
+export default function CookieConsent() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    // Honor an existing choice or a Global Privacy Control opt-out signal.
+    if (hasGlobalPrivacyControlOptOut()) {
+      storeConsent('denied')
+      return
+    }
+    const stored = getStoredConsent()
+    if (stored === 'granted') {
+      loadGoogleAnalytics()
+      return
+    }
+    if (stored === 'denied') return
+    // Deliberate mount-time reveal: the banner must stay out of the prerendered
+    // HTML and appear only after hydration confirms no prior choice exists.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setVisible(true)
+  }, [])
+
+  const accept = () => {
+    storeConsent('granted')
+    loadGoogleAnalytics()
+    setVisible(false)
+  }
+
+  const decline = () => {
+    storeConsent('denied')
+    setVisible(false)
+  }
+
+  if (!visible) return null
+
+  return (
+    <div
+      className="cookie-consent"
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="cookie-consent-title"
+      aria-describedby="cookie-consent-desc"
+    >
+      <div className="cookie-consent-inner">
+        <div className="cookie-consent-text">
+          <p id="cookie-consent-title" className="cookie-consent-title">
+            We value your privacy
+          </p>
+          <p id="cookie-consent-desc">
+            We use strictly necessary cookies to run this site. With your consent we also use
+            Google Analytics to understand how the site is used. Analytics stays off unless you
+            accept. See our <Link to="/cookies">Cookie Notice</Link> and{' '}
+            <Link to="/privacy">Privacy Policy</Link>.
+          </p>
+        </div>
+        <div className="cookie-consent-actions">
+          <button type="button" className="btn btn-outline" onClick={decline}>
+            Decline
+          </button>
+          <button type="button" className="btn btn-primary" onClick={accept}>
+            Accept analytics
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/website/src/components/ErrorBoundary.tsx
+++ b/website/src/components/ErrorBoundary.tsx
@@ -75,7 +75,7 @@ export default class ErrorBoundary extends Component<Props, State> {
               }}
               style={{
                 padding: '14px 28px',
-                background: '#2ECC71',
+                background: '#157F43',
                 color: 'white',
                 border: 'none',
                 borderRadius: 12,

--- a/website/src/components/Footer.css
+++ b/website/src/components/Footer.css
@@ -87,17 +87,17 @@
 }
 
 .footer-note {
-  color: var(--gray-500);
+  /* gray-400 (#9ca3af) clears 4.5:1 on gray-900; gray-500 was ~3.7:1 (fails 1.4.3). */
+  color: var(--gray-400);
 }
 
 .footer-admin-link {
-  color: var(--gray-500);
-  opacity: 0.6;
-  transition: opacity 0.15s ease;
+  /* No opacity dimming — it dropped effective contrast below 2:1 (fails 1.4.3). */
+  color: var(--gray-400);
+  transition: color 0.15s ease;
 }
 
 .footer-admin-link:hover {
-  opacity: 1;
   color: var(--green-400);
 }
 

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -27,7 +27,7 @@ export default function Header() {
           <img src="/Logo.svg" alt="Daily OK" style={{ height: '36px', width: 'auto' }} />
         </Link>
 
-        <nav className={`nav ${menuOpen ? 'nav-open' : ''}`} role="navigation" aria-label="Main navigation">
+        <nav id="primary-navigation" className={`nav ${menuOpen ? 'nav-open' : ''}`} role="navigation" aria-label="Main navigation">
           <Link
             to="/"
             className={`nav-link ${isActive('/') ? 'active' : ''}`}
@@ -83,6 +83,7 @@ export default function Header() {
           onClick={() => setMenuOpen(!menuOpen)}
           aria-label="Toggle menu"
           aria-expanded={menuOpen}
+          aria-controls="primary-navigation"
         >
           {menuOpen ? <X size={24} /> : <Menu size={24} />}
         </button>

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom'
 import Header from './Header'
 import Footer from './Footer'
+import CookieConsent from './CookieConsent'
 
 export default function Layout() {
   return (
@@ -13,6 +14,7 @@ export default function Layout() {
         <Outlet />
       </main>
       <Footer />
+      <CookieConsent />
     </>
   )
 }

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -7,7 +7,9 @@ export default function Layout() {
     <>
       <a href="#main-content" className="skip-link">Skip to main content</a>
       <Header />
-      <main id="main-content">
+      {/* tabIndex=-1 makes this a programmatic focus target for the skip link
+          and for RouteFocusManager on SPA navigation (WCAG 2.4.3). */}
+      <main id="main-content" tabIndex={-1}>
         <Outlet />
       </main>
       <Footer />

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -10,6 +10,15 @@
   --green-800: #166534;
   --green-900: #14532d;
 
+  /*
+    Accessible brand green for WHITE text / small body text.
+    Brand green (--green-500 #2ECC71) is ~2.1:1 on white and fails WCAG AA;
+    keep it for large decorative fills only. Use --green-accessible (5.06:1
+    with white) for button fills and link text so text-on-green meets 1.4.3 AA.
+  */
+  --green-accessible: #157F43;
+  --green-accessible-hover: #11642F;
+
   --gray-50: #f9fafb;
   --gray-100: #f3f4f6;
   --gray-200: #e5e7eb;
@@ -55,12 +64,12 @@ body {
 }
 
 a {
-  color: var(--green-600);
+  color: var(--green-accessible);
   text-decoration: none;
   transition: color 0.2s;
 }
 a:hover {
-  color: var(--green-700);
+  color: var(--green-accessible-hover);
 }
 
 img {
@@ -102,24 +111,24 @@ img {
 }
 
 .btn-primary {
-  background: var(--green-500);
+  background: var(--green-accessible);
   color: var(--white);
 }
 .btn-primary:hover {
-  background: var(--green-600);
+  background: var(--green-accessible-hover);
   color: var(--white);
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(46, 204, 113, 0.4);
+  box-shadow: 0 4px 12px rgba(21, 127, 67, 0.4);
 }
 
 .btn-secondary {
   background: var(--white);
-  color: var(--green-700);
+  color: var(--green-accessible);
   border: 2px solid var(--green-200);
 }
 .btn-secondary:hover {
   background: var(--green-50);
-  color: var(--green-700);
+  color: var(--green-accessible-hover);
   border-color: var(--green-300);
 }
 
@@ -140,6 +149,12 @@ img {
   outline-offset: 2px;
 }
 
+/* Programmatic focus target (skip link + SPA route change): don't paint a
+   full-width outline box around the whole <main> when it receives focus. */
+#main-content:focus {
+  outline: none;
+}
+
 /* Skip-to-main-content link */
 .skip-link {
   position: absolute;
@@ -155,4 +170,20 @@ img {
 }
 .skip-link:focus {
   top: 16px;
+}
+
+/*
+  Respect the user's "Reduce Motion" OS setting (WCAG 2.3.3 / matches the
+  published Accessibility Statement). Neutralizes transitions, transforms,
+  and infinite animations (e.g. the route-loading spinner) for these users.
+*/
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/website/src/lib/consent.ts
+++ b/website/src/lib/consent.ts
@@ -1,0 +1,74 @@
+/**
+ * Cookie-consent + Google Analytics gating for the Daily OK website.
+ *
+ * Google Analytics (GA4) sets cookies and transfers data to Google, so under
+ * the EU ePrivacy Directive / GDPR it requires PRIOR opt-in consent. This
+ * module keeps GA fully unloaded until the visitor explicitly accepts:
+ *   - No stored choice  -> banner shown, GA not loaded.
+ *   - "granted"         -> GA loaded.
+ *   - "denied"          -> GA never loaded.
+ *   - Global Privacy Control present -> treated as an opt-out, GA never loaded.
+ *
+ * The GA tag is intentionally NOT in the prerendered <head> (see
+ * pages/+onRenderHtml.tsx); it is injected here only after consent.
+ */
+
+const CONSENT_KEY = 'dailyok_cookie_consent'
+const GA_MEASUREMENT_ID = 'G-J2H67EW9JY'
+
+export type ConsentChoice = 'granted' | 'denied'
+
+export function getStoredConsent(): ConsentChoice | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const value = window.localStorage.getItem(CONSENT_KEY)
+    return value === 'granted' || value === 'denied' ? value : null
+  } catch {
+    return null
+  }
+}
+
+export function storeConsent(choice: ConsentChoice): void {
+  if (typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(CONSENT_KEY, choice)
+  } catch {
+    // Storage may be unavailable (private mode / blocked); fail closed.
+  }
+}
+
+/**
+ * Global Privacy Control — a legally recognized opt-out preference signal
+ * (honored under CPRA, Colorado, Connecticut, etc.). When present we treat
+ * analytics as declined without prompting.
+ */
+export function hasGlobalPrivacyControlOptOut(): boolean {
+  if (typeof navigator === 'undefined') return false
+  return (navigator as Navigator & { globalPrivacyControl?: boolean }).globalPrivacyControl === true
+}
+
+let gaLoaded = false
+
+/**
+ * Inject and initialize GA4. Idempotent and safe to call more than once.
+ * Only call after consent === 'granted'.
+ */
+export function loadGoogleAnalytics(): void {
+  if (gaLoaded || typeof window === 'undefined' || typeof document === 'undefined') return
+  gaLoaded = true
+
+  const script = document.createElement('script')
+  script.async = true
+  script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`
+  document.head.appendChild(script)
+
+  const w = window as unknown as { dataLayer: unknown[]; gtag: (...args: unknown[]) => void }
+  w.dataLayer = w.dataLayer || []
+  w.gtag = function gtag() {
+    // GA expects the raw `arguments` object pushed onto dataLayer.
+    // eslint-disable-next-line prefer-rest-params
+    w.dataLayer.push(arguments)
+  }
+  w.gtag('js', new Date())
+  w.gtag('config', GA_MEASUREMENT_ID, { anonymize_ip: true })
+}

--- a/website/src/pages/Accessibility.tsx
+++ b/website/src/pages/Accessibility.tsx
@@ -11,7 +11,7 @@ export default function Accessibility() {
         path="/accessibility"
         keywords="accessible check-in app, voiceover support, elderly friendly app, senior friendly iPhone app, large text app for seniors"
       />
-    <main className="legal-page">
+    <div className="legal-page">
       <div className="container">
         <div className="legal-content">
           <h1>Accessibility Statement</h1>
@@ -43,8 +43,9 @@ export default function Accessibility() {
                 without loss of content or functionality.
               </li>
               <li>
-                <strong>Dark mode support</strong> — a full dark appearance is available to
-                reduce eye strain and improve readability in low-light settings.
+                <strong>Dark mode support (mobile app)</strong> — the iOS app offers a full
+                dark appearance to reduce eye strain and improve readability in low-light
+                settings.
               </li>
               <li>
                 <strong>Color-independent status indicators</strong> — we use icons alongside
@@ -95,7 +96,7 @@ export default function Accessibility() {
           </section>
         </div>
       </div>
-    </main>
+    </div>
     </>
   )
 }

--- a/website/src/pages/BlogPost.tsx
+++ b/website/src/pages/BlogPost.tsx
@@ -156,7 +156,7 @@ export default function BlogPost() {
           <h1>{post.title}</h1>
           {post.excerpt && <p className="blog-article-lede">{post.excerpt}</p>}
           {post.featured_image_url && (
-            <img src={post.featured_image_url} alt="" className="blog-article-hero" />
+            <img src={post.featured_image_url} alt={post.title} className="blog-article-hero" />
           )}
 
           <div className="blog-article-body" dangerouslySetInnerHTML={{ __html: safeHtml }} />

--- a/website/src/pages/Cookies.tsx
+++ b/website/src/pages/Cookies.tsx
@@ -3,7 +3,7 @@ import './Legal.css'
 
 export default function Cookies() {
   return (
-    <main className="legal-page">
+    <div className="legal-page">
       <SEO
         title="Cookie Notice"
         description="How Daily OK uses (and does not use) cookies and similar technologies on our website and apps."
@@ -101,6 +101,6 @@ export default function Cookies() {
           </section>
         </div>
       </div>
-    </main>
+    </div>
   )
 }

--- a/website/src/pages/Cookies.tsx
+++ b/website/src/pages/Cookies.tsx
@@ -12,14 +12,16 @@ export default function Cookies() {
       <div className="container">
         <div className="legal-content">
           <h1>Cookie Notice</h1>
-          <p className="legal-updated">Last updated: April 13, 2026</p>
+          <p className="legal-updated">Last updated: July 23, 2026</p>
 
           <section>
             <h2>Overview</h2>
             <p>
               Daily OK is built around the principle of data minimization. We do not use
-              advertising cookies, behavioral-tracking cookies, or third-party marketing
-              pixels on our website (dailyok.net) or in our mobile apps.
+              advertising cookies or third-party marketing pixels on our website
+              (dailyok.net) or in our mobile apps. The only cookies that are not strictly
+              necessary are the optional analytics cookies described below, which are set
+              only if you consent.
             </p>
           </section>
 
@@ -49,8 +51,25 @@ export default function Cookies() {
               are popular. Cloudflare Web Analytics{' '}
               <strong>does not set cookies, does not use fingerprinting, and does not
               collect personally identifiable information.</strong> Because no cookies or
-              persistent identifiers are set, no consent prompt is required under the EU
+              persistent identifiers are set, it runs without a consent prompt under the EU
               ePrivacy Directive or comparable laws.
+            </p>
+
+            <h3>Analytics Cookies (Optional — Only With Your Consent)</h3>
+            <p>
+              With your consent, we also use <strong>Google Analytics (GA4)</strong>,
+              provided by Google LLC, to understand how visitors use the site so we can
+              improve it. Google Analytics sets first-party cookies (such as{' '}
+              <code>_ga</code>) and transfers data to Google. We enable IP anonymization and
+              do not use Google Analytics for advertising.
+            </p>
+            <p>
+              Google Analytics is <strong>off by default</strong>. When you first visit the
+              site we show a consent banner; Google Analytics is only loaded if you choose{' '}
+              <em>Accept analytics</em>. If you decline — or if your browser sends a Global
+              Privacy Control (GPC) signal — Google Analytics is never loaded. You can change
+              your mind at any time by clearing this site's browser storage, which resets the
+              banner so you can choose again.
             </p>
 
             <h3>Categories We Do Not Use</h3>
@@ -58,7 +77,7 @@ export default function Cookies() {
               <li>Advertising or remarketing cookies</li>
               <li>Cross-site tracking pixels (Facebook Pixel, Google Ads, etc.)</li>
               <li>Third-party social-media share buttons that load tracking scripts</li>
-              <li>Session-replay or behavioral analytics tools</li>
+              <li>Session-replay tools (heatmaps or mouse-movement recording)</li>
             </ul>
           </section>
 
@@ -85,10 +104,10 @@ export default function Cookies() {
           <section>
             <h2>Changes to This Notice</h2>
             <p>
-              If we ever introduce a new technology that requires consent (for example,
-              optional product analytics that set a cookie), we will update this notice and
-              present a consent banner before the technology is loaded. Any change will be
-              reflected in the "Last updated" date above.
+              If we introduce a new technology that requires consent, we will update this
+              notice and present it in the consent banner before the technology is loaded, so
+              you can accept or decline. Any change will be reflected in the "Last updated"
+              date above.
             </p>
           </section>
 

--- a/website/src/pages/DMCA.tsx
+++ b/website/src/pages/DMCA.tsx
@@ -3,7 +3,7 @@ import './Legal.css'
 
 export default function DMCA() {
   return (
-    <main className="legal-page">
+    <div className="legal-page">
       <SEO
         title="DMCA Copyright Policy"
         description="How to submit a copyright takedown notice or counter-notice for content on Daily OK."
@@ -110,6 +110,6 @@ export default function DMCA() {
           </section>
         </div>
       </div>
-    </main>
+    </div>
   )
 }

--- a/website/src/pages/Home.css
+++ b/website/src/pages/Home.css
@@ -323,7 +323,7 @@
   margin: 0 auto 16px;
 }
 
-.no-track-item h4 {
+.no-track-item h3 {
   font-size: 16px;
   color: var(--white);
   margin-bottom: 6px;
@@ -358,7 +358,7 @@
   margin-bottom: 12px;
 }
 
-.use-case h4 {
+.use-case h3 {
   font-size: 17px;
   font-weight: 600;
   color: var(--gray-900);

--- a/website/src/pages/Home.tsx
+++ b/website/src/pages/Home.tsx
@@ -263,7 +263,7 @@ export default function Home() {
           <div className="no-tracking-grid">
             <div className="no-track-item">
               <div className="no-icon"><MapPin size={24} /></div>
-              <h4>Location Is Optional</h4>
+              <h3>Location Is Optional</h3>
               <p>
                 Receivers can choose to attach a location pin to their check-in. Location is
                 only collected with your permission, never sold, and can be turned off at any
@@ -272,17 +272,17 @@ export default function Home() {
             </div>
             <div className="no-track-item">
               <div className="no-icon"><Camera size={24} /></div>
-              <h4>No Cameras or Sensors</h4>
+              <h3>No Cameras or Sensors</h3>
               <p>No video, no audio monitoring, no wearables required.</p>
             </div>
             <div className="no-track-item">
               <div className="no-icon"><Mic size={24} /></div>
-              <h4>No Microphone Access</h4>
+              <h3>No Microphone Access</h3>
               <p>We never request or use the microphone.</p>
             </div>
             <div className="no-track-item">
               <div className="no-icon"><Shield size={24} /></div>
-              <h4>GDPR & CCPA/CPRA Compliant</h4>
+              <h3>GDPR & CCPA/CPRA Compliant</h3>
               <p>Full data export, deletion, and retention controls — yours to manage.</p>
             </div>
           </div>
@@ -300,7 +300,7 @@ export default function Home() {
           <div className="use-cases-grid">
             <div className="use-case">
               <div className="use-case-emoji" role="img" aria-label="Elderly woman">👵</div>
-              <h4>Aging Parents & Dementia Care</h4>
+              <h3>Aging Parents & Dementia Care</h3>
               <p>
                 Adult children checking on parents living alone — especially those with
                 early-stage dementia or Alzheimer's. A simple, dignified daily wellness check
@@ -310,7 +310,7 @@ export default function Home() {
             </div>
             <div className="use-case">
               <div className="use-case-emoji" role="img" aria-label="Children playing">👦</div>
-              <h4>Kids & Teens</h4>
+              <h3>Kids & Teens</h3>
               <p>
                 Parents of children playing outside, walking home from school, or staying home
                 alone. A quick daily check-in so you know they're safe — without hovering.
@@ -319,7 +319,7 @@ export default function Home() {
             </div>
             <div className="use-case">
               <div className="use-case-emoji" role="img" aria-label="Globe">🌍</div>
-              <h4>Long-Distance Families</h4>
+              <h3>Long-Distance Families</h3>
               <p>
                 Stay connected with family across states or countries. A daily "I'm OK" signal
                 that bridges the distance and eases the worry.
@@ -327,7 +327,7 @@ export default function Home() {
             </div>
             <div className="use-case">
               <div className="use-case-emoji" role="img" aria-label="Stethoscope">🩺</div>
-              <h4>Family & Professional Caregivers</h4>
+              <h3>Family & Professional Caregivers</h3>
               <p>
                 Whether you're a professional caregiver or a family member coordinating care,
                 Daily OK provides a reliable daily wellness signal with history and PDF reports

--- a/website/src/pages/Pricing.css
+++ b/website/src/pages/Pricing.css
@@ -63,7 +63,7 @@
   white-space: nowrap;
 }
 
-.plan-header h3 {
+.plan-header h2 {
   font-size: 22px;
   font-weight: 700;
   color: var(--gray-900);
@@ -181,7 +181,7 @@
   gap: 24px;
 }
 
-.addon-card h4 {
+.addon-card h3 {
   font-size: 16px;
   font-weight: 600;
   color: var(--gray-900);
@@ -220,7 +220,7 @@
   margin: 0 auto;
 }
 
-.faq-item h4 {
+.faq-item h3 {
   font-size: 16px;
   font-weight: 600;
   color: var(--gray-900);

--- a/website/src/pages/Pricing.tsx
+++ b/website/src/pages/Pricing.tsx
@@ -136,7 +136,7 @@ export default function Pricing() {
               >
                 {plan.highlight && <div className="plan-badge">Most Popular</div>}
                 <div className="plan-header">
-                  <h3>{plan.name}</h3>
+                  <h2>{plan.name}</h2>
                   <div className="plan-price">
                     <span className="price-amount">{plan.price}</span>
                     <span className="price-period">{plan.period}</span>
@@ -241,7 +241,7 @@ export default function Pricing() {
             {addons.map((addon) => (
               <div key={addon.name} className="addon-card">
                 <div>
-                  <h4>{addon.name}</h4>
+                  <h3>{addon.name}</h3>
                   <p>{addon.description}</p>
                 </div>
                 <div className="addon-price">
@@ -263,7 +263,7 @@ export default function Pricing() {
           <div className="faq-grid">
             {pricingFaqs.map((faq) => (
               <div key={faq.q} className="faq-item">
-                <h4>{faq.q}</h4>
+                <h3>{faq.q}</h3>
                 <p>
                   {faq.a}
                   {faq.q === 'Is my data safe?' && (

--- a/website/src/pages/Privacy.tsx
+++ b/website/src/pages/Privacy.tsx
@@ -13,7 +13,7 @@ export default function Privacy() {
       <div className="container">
         <div className="legal-content">
           <h1>Privacy Policy</h1>
-          <p className="legal-updated">Last updated: June 15, 2026</p>
+          <p className="legal-updated">Last updated: July 23, 2026</p>
 
           <section>
             <h2>Introduction</h2>
@@ -34,7 +34,7 @@ export default function Privacy() {
             <h2>Summary of Key Practices</h2>
             <ul>
               <li>We do not sell or "share" personal information for cross-context behavioral advertising.</li>
-              <li>We do not use third-party advertising or tracking SDKs.</li>
+              <li>We do not use third-party advertising SDKs or cross-company tracking. Optional website analytics (Google Analytics) runs only if you consent to it.</li>
               <li>Location is optional and only collected with your in-app permission.</li>
               <li>You can export or delete your data at any time from app settings.</li>
               <li>We honor opt-out and deletion requests for residents of all U.S. states with applicable privacy laws.</li>
@@ -86,8 +86,10 @@ export default function Privacy() {
                 usage counts and crash reports. Our mobile apps use TelemetryDeck, which
                 one-way hashes identifiers on the device before sending, and our website uses
                 Cloudflare Web Analytics, which does not set cookies or identify individuals.
-                Neither provider is used for advertising, and we do not share usage data with
-                data brokers.
+                In addition, if you consent via our cookie banner, the website uses Google
+                Analytics (GA4) with IP anonymization; Google Analytics is not loaded unless
+                you accept, and never for advertising. None of these providers are used for
+                advertising, and we do not share usage data with data brokers.
               </li>
               <li>
                 <strong>Log Data:</strong> Server logs (IP address, request path, status, and
@@ -225,6 +227,7 @@ export default function Privacy() {
               <li><strong>Supabase (PostgreSQL hosting and authentication)</strong> — primary application database, encrypted at rest.</li>
               <li><strong>Contabo / Coolify (VPS hosting)</strong> — hosts our edge functions in the European Union.</li>
               <li><strong>Cloudflare</strong> — content delivery, DDoS protection, and privacy-first web analytics.</li>
+              <li><strong>Google LLC (Google Analytics)</strong> — optional website usage analytics, loaded only with your consent. Configured with IP anonymization and not used for advertising.</li>
               <li><strong>TelemetryDeck</strong> — aggregate, hashed analytics for the iOS and Android apps. User identifiers are one-way hashed before leaving the device; no personal information is transmitted.</li>
               <li><strong>Sentry</strong> — application error and crash reporting for our apps, website, and backend, used to detect and fix defects. Configured not to send personal information by default; may process technical data such as IP address and error context.</li>
               <li><strong>Apple Push Notification service (APNs)</strong> — delivery of iOS push notifications.</li>
@@ -356,10 +359,13 @@ export default function Privacy() {
           <section>
             <h2>Cookies and Similar Technologies</h2>
             <p>
-              The Daily OK website does not use advertising cookies or third-party tracking
+              The Daily OK website does not use advertising cookies or cross-site tracking
               cookies. We use a small number of strictly necessary technologies to operate the
               site (for example, session storage for navigation state) and a privacy-first
-              analytics provider that does not set cookies. See our{' '}
+              analytics provider that does not set cookies. With your consent, we also use
+              Google Analytics, which sets first-party analytics cookies; it is off by default
+              and loaded only if you accept our cookie banner (and never if your browser sends
+              a Global Privacy Control signal). See our{' '}
               <a href="/cookies">Cookie Notice</a> for details.
             </p>
           </section>

--- a/website/src/pages/Privacy.tsx
+++ b/website/src/pages/Privacy.tsx
@@ -3,7 +3,7 @@ import './Legal.css'
 
 export default function Privacy() {
   return (
-    <main className="legal-page">
+    <div className="legal-page">
       <SEO
         title="Privacy Policy"
         description="Daily OK privacy policy. Transparent data practices, optional location, GDPR, CCPA/CPRA, COPPA, and state privacy law compliance."
@@ -226,6 +226,7 @@ export default function Privacy() {
               <li><strong>Contabo / Coolify (VPS hosting)</strong> — hosts our edge functions in the European Union.</li>
               <li><strong>Cloudflare</strong> — content delivery, DDoS protection, and privacy-first web analytics.</li>
               <li><strong>TelemetryDeck</strong> — aggregate, hashed analytics for the iOS and Android apps. User identifiers are one-way hashed before leaving the device; no personal information is transmitted.</li>
+              <li><strong>Sentry</strong> — application error and crash reporting for our apps, website, and backend, used to detect and fix defects. Configured not to send personal information by default; may process technical data such as IP address and error context.</li>
               <li><strong>Apple Push Notification service (APNs)</strong> — delivery of iOS push notifications.</li>
               <li><strong>Google Firebase Cloud Messaging (FCM)</strong> — delivery of Android push notifications.</li>
               <li><strong>Twilio (SMS)</strong> — escalation text messages where SMS fallback is enabled.</li>
@@ -416,6 +417,6 @@ export default function Privacy() {
           </section>
         </div>
       </div>
-    </main>
+    </div>
   )
 }

--- a/website/src/pages/Support.css
+++ b/website/src/pages/Support.css
@@ -40,7 +40,7 @@
   color: var(--green-500);
 }
 
-.contact-card h3 {
+.contact-card h2 {
   font-size: 18px;
   font-weight: 600;
   color: var(--gray-900);
@@ -128,7 +128,7 @@
   padding: 48px 40px;
 }
 
-.support-cta-card h3 {
+.support-cta-card h2 {
   font-size: 24px;
   font-weight: 700;
   color: var(--gray-900);

--- a/website/src/pages/Support.tsx
+++ b/website/src/pages/Support.tsx
@@ -80,7 +80,7 @@ export default function Support() {
           <div className="contact-grid">
             <div className="contact-card">
               <Mail size={28} />
-              <h3>Email Support</h3>
+              <h2>Email Support</h2>
               <p>Get help from our team. We typically respond within 24 hours.</p>
               <a href="mailto:support@dailyok.net" className="btn btn-secondary">
                 support@dailyok.net
@@ -88,7 +88,7 @@ export default function Support() {
             </div>
             <div className="contact-card">
               <MessageCircle size={28} />
-              <h3>In-App Support</h3>
+              <h2>In-App Support</h2>
               <p>Family+ subscribers get priority support directly within the app.</p>
               <Link to="/pricing" className="btn btn-secondary">
                 View Plans
@@ -96,7 +96,7 @@ export default function Support() {
             </div>
             <div className="contact-card">
               <FileText size={28} />
-              <h3>Legal & Privacy</h3>
+              <h2>Legal & Privacy</h2>
               <p>Questions about your data, privacy rights, or our policies.</p>
               <a href="mailto:privacy@dailyok.net" className="btn btn-secondary">
                 privacy@dailyok.net
@@ -127,7 +127,7 @@ export default function Support() {
       <section className="section support-cta">
         <div className="container">
           <div className="support-cta-card">
-            <h3>Still need help?</h3>
+            <h2>Still need help?</h2>
             <p>
               Our support team is here for you. Reach out anytime and we'll get back
               to you as soon as possible.

--- a/website/src/pages/Terms.tsx
+++ b/website/src/pages/Terms.tsx
@@ -3,7 +3,7 @@ import './Legal.css'
 
 export default function Terms() {
   return (
-    <main className="legal-page">
+    <div className="legal-page">
       <SEO
         title="Terms of Use"
         description="Daily OK terms of use. Subscription terms, acceptable use, dispute resolution, and arbitration agreement for the daily family check-in app."
@@ -404,6 +404,6 @@ export default function Terms() {
           </section>
         </div>
       </div>
-    </main>
+    </div>
   )
 }


### PR DESCRIPTION
Runs a full compliance audit across required legal pages, ADA/WCAG 2.1 AA
accessibility, and GDPR + US state privacy law, and lands the unambiguous
accessibility fixes plus the audit report.

Accessibility (WCAG 2.1 AA):
- Add --green-accessible (#157F43, 5.06:1 on white); apply to primary/
  secondary buttons, links, and the ErrorBoundary button. Brand green
  (#2ECC71) was ~2.1:1 white-on-green and links ~3.1:1 — both failed 1.4.3.
- Remove nested <main> landmarks: inner <main> -> <div> on Privacy, Terms,
  Cookies, DMCA, and Accessibility (Layout already provides the sole main).
- Add prefers-reduced-motion global rule (matches the a11y statement).
- Manage focus + scroll on SPA route change (RouteFocusManager, focusable
  main) so keyboard/AT users land on the new page (2.4.3).
- Fix heading-order skips on Home, Pricing, and Support (+ matching CSS).
- Raise footer secondary-text contrast; add menu aria-controls; give the
  blog hero image a real alt.

Legal-doc accuracy:
- Disclose the Sentry sub-processor in the Privacy Policy.
- Scope the "dark mode" accessibility claim to the mobile app.

Docs:
- Add docs/COMPLIANCE_AUDIT.md: full findings, severity, and remediation,
  including items that need a business decision or real data (Google
  Analytics vs. the no-tracking policy, placeholder business address, the
  auth.users deletion and data-export-completeness backend defects, COPPA
  age gating, and an EU/UK Art. 27 representative).

Verified: tsc -b, vite build, and targeted ESLint on changed files pass.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NzNH7omrkeA1kjmy7oUgQz